### PR TITLE
【2020/04/09】首都大学東京の改称

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ layout: default
     <div class="service-one">
       <img src="/assets/img/illustration/sp-creator.svg" alt="スーパークリエータ認定" class="service-img">
       <h3>スーパークリエータ認定</h3>
-      <p>特に顕著な成果を残した方を未踏ジュニアスーパークリエータとして認定します。<a href="https://www.sfc.keio.ac.jp/news/012903.html">慶應義塾大学SFC</a>や<a href="https://www.tmu.ac.jp/entrance/revision/y2021/tayou.html">首都大学東京</a>に推薦枠で出願できます</p>
+      <p>特に顕著な成果を残した方を未踏ジュニアスーパークリエータとして認定します。<a href="https://www.sfc.keio.ac.jp/news/012903.html">慶應義塾大学SFC</a>や<a href="https://www.tmu.ac.jp/entrance/revision/y2021/tayou.html">東京都立大学システムデザイン学部</a>に推薦枠で出願できます</p>
     </div>
     <a href="/about" class="button">詳細を見る</a>
   </div>


### PR DESCRIPTION
2020年4月1日に首都大学東京は東京都立大学に改称されるため一部書き換えました。(https://www.tmu.ac.jp/news/topics/about_rename/info/19265.html)
また、「慶應義塾大学SFC」が大学名+学部名で表されているので東京都立大学も合わせて大学名+学部名にしてみました。