### PR TITLE
Internationalize shared sections with English dictionary and layout

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -1,0 +1,28 @@
+sponsorHeading:
+  ja: 'スポンサー'
+  en: 'Sponsors'
+
+sponsorGold:
+  ja: 'ゴールドスポンサー'
+  en: 'Gold Sponsor'
+
+sponsorSilver:
+  ja: 'シルバースポンサー'
+  en: 'Silver Sponsor'
+
+sponsorBronze:
+  ja: 'ブロンズスポンサー'
+  en: 'Bronze Sponsor'
+
+sponsorInkind:
+  ja: '機材・教材提供'
+  en: 'In-kind Sponsor'
+
+sponsorMedia:
+  ja: 'メディアパートナー'
+  en: 'Media Partner'
+
+sponsorText:
+  ja: '<p>未踏ジュニア実行委員会では、未踏ジュニアの継続的な活動を支援して頂けるスポンサー様を随時募集しております。</p><p>興味を持って頂いた法人・個人の方は <a href="mailto:jr@mitou.org"><i>jr@mitou.org</i></a> までご連絡頂けると幸いです。</p>'
+  en: '<p>Interested in sponsoring us?</p><p>Feel free to contact <a href="mailto:jr@mitou.org"><i>jr@mitou.org</i></a> to find out what we can do together!</p>'
+

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -26,3 +26,19 @@ sponsorText:
   ja: '<p>未踏ジュニア実行委員会では、未踏ジュニアの継続的な活動を支援して頂けるスポンサー様を随時募集しております。</p><p>興味を持って頂いた法人・個人の方は <a href="mailto:jr@mitou.org"><i>jr@mitou.org</i></a> までご連絡頂けると幸いです。</p>'
   en: '<p>Interested in sponsoring us?</p><p>Feel free to contact <a href="mailto:jr@mitou.org"><i>jr@mitou.org</i></a> to find out what we can do together!</p>'
 
+supporterHeading:
+  ja: '後援'
+  en: 'Supporters'
+
+collaboratorHeading:
+  ja: '協力団体'
+  en: 'Collaborators'
+
+contactHeading:
+  ja: 'お問い合わせ'
+  en: 'Contact'
+
+contactText:
+  ja: '<p>お返事が遅くなる場合もありますが、ご了承ください。<br>チラシ配布にご協力頂ける方は<a href="/flyer">コチラ</a>からご請求をお願い致します。</p><a href="/q-box" class="button">匿名質問箱はこちら</a>'
+  en: '<p>Let us know if you have any questions.<br> We have limited resources and receive many inquiries so may be late to reply.</p><p>Thanks for your cooperation.</p>'
+

--- a/_includes/collaborators.html
+++ b/_includes/collaborators.html
@@ -1,0 +1,12 @@
+{% assign lang = page.lang | default: "ja" %}
+
+<section id="collaborators">
+  <h2>{{ site.data.translations.collaboratorHeading[lang] }}</h2>
+  <div class="sponsors-list-clb">
+    {% for c in site.data.collaborators %}
+    <a href="{{c.url}}" class="sponsor-clb sponsor-one" target="_blank">
+      <img src="/assets/img/sponsors/{{c.img}}" alt="{{c.name}}" class="sponsor-img">
+    </a>
+    {% endfor %}
+  </div>
+</section>

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,0 +1,11 @@
+{% assign lang = page.lang | default: "ja" %}
+
+<section id="contact">
+  <h2 class="heading-line">{{ site.data.translations.contactHeading[lang] }}</h2>
+  <p></p>
+
+  <i class="fas fa-envelope green" style="font-size:36px;"></i><br>
+  <a href="mailto:jr@mitou.org">jr@mitou.org</a>
+
+  {{ site.data.translations.contactText[lang] }}
+</section>

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -1,10 +1,13 @@
 <!-- 以下スポンサー様一覧のHTMLです。
   HTMLは/_includes/sponsors.htmlを、スポンサー情報は/_data/sponsors.ymlを参照してください。 -->
 
-<section id="sponsors">
-  <h2 class="heading-line">スポンサー</h2>
+{% assign lang = page.lang | default: "ja" %}
 
-  <h3>ゴールドスポンサー</h3>
+<section id="sponsors">
+
+  <h2 class="heading-line">{{ site.data.translations.sponsorHeading[lang] }}</h2>
+
+  <h3>{{ site.data.translations.sponsorGold[lang] }}</h3>
   <div class="sponsors-list-gold">
     {% for sponsor in site.data.sponsors.gold %}
     <a href="{{sponsor.url}}" target="_blank">
@@ -15,7 +18,7 @@
     {% endfor %}
   </div>
 
-  <h3>シルバースポンサー</h3>
+  <h3>{{ site.data.translations.sponsorSilver[lang] }}</h3>
   <div class="sponsors-list-silver">
     {% for sponsor in site.data.sponsors.silver %}
     <a href="{{sponsor.url}}" target="_blank">
@@ -26,7 +29,7 @@
     {% endfor %}
   </div>
 
-  <h3>ブロンズスポンサー</h3>
+  <h3>{{ site.data.translations.sponsorBronze[lang] }}</h3>
   <div class="sponsors-list-bronze">
     {% for sponsor in site.data.sponsors.bronze %}
     <a href="{{sponsor.url}}" target="_blank">
@@ -37,7 +40,7 @@
     {% endfor %}
   </div>
 
-  <h3>機材・教材提供</h3>
+  <h3>{{ site.data.translations.sponsorInkind[lang] }}</h3>
   <div class="sponsors-list-eq">
     {% for sponsor in site.data.sponsors.equipment %}
     <a href="{{sponsor.url}}" class="sponsor-eq sponsor-one" target="_blank">
@@ -46,7 +49,7 @@
     {% endfor %}
   </div>
 
-  <h3>メディアパートナー</h3>
+  <h3>{{ site.data.translations.sponsorMedia[lang] }}</h3>
   <div class="sponsors-list-media">
     {% for sponsor in site.data.sponsors.media %}
     <a href="{{sponsor.url}}" class="sponsor-media sponsor-one" target="_blank">
@@ -56,8 +59,8 @@
   </div>
 
   <div class="sponsors-text-for-inquiry">
-    <p>未踏ジュニア実行委員会では、未踏ジュニアの継続的な活動を支援して頂けるスポンサー様を随時募集しております。</p>
-    <p>興味を持って頂いた法人・個人の方は <a href="mailto:jr@mitou.org"><i>jr@mitou.org</i></a> までご連絡頂けると幸いです。</p>
+    {{ site.data.translations.sponsorText[lang] }}
   </div>
 
 </section>
+

--- a/_includes/supporters.html
+++ b/_includes/supporters.html
@@ -1,0 +1,17 @@
+{% assign lang = page.lang | default: "ja" %}
+
+<section id="supporters">
+  <h2>{{ site.data.translations.supporterHeading[lang] }}</h2>
+  <div class="sponsors-list-supporter">
+    <a href="https://www.mext.go.jp/" target="_blank">
+      <div class="sponsor-supporter sponsor-one">
+        <img src="/assets/img/sponsors/mext.png" alt="文部科学省" class="sponsor-img">
+      </div>
+    </a>
+    <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
+      <div class="sponsor-supporter sponsor-one">
+        <img src="/assets/img/sponsors/meti.png" alt="経済産業省" class="sponsor-img">
+      </div>
+    </a>
+  </div>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="ja" dir="ltr">
+
+{% assign lang = page.lang | default: "ja" %}
+
+<html lang="{{ lang }}" dir="ltr">
 <head>
   <meta charset="utf-8">
 
@@ -78,6 +81,7 @@
   <div class="main">
     {{ content }}
   </div>
+
   {% include footer.html %}
 </body>
 

--- a/_layouts/english.html
+++ b/_layouts/english.html
@@ -2,6 +2,8 @@
 layout: default
 ---
 
+{% assign lang = page.lang | default: "en" %}
+
 <div class="cover-photo">
   <img src="/assets/img/2019_all.png" alt="Mitou Junior Photo in 2019" class="top-img" style="margin-bottom: -8px;">
 

--- a/_layouts/english.html
+++ b/_layouts/english.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<div class="cover-photo">
+  <img src="/assets/img/2019_all.png" alt="Mitou Junior Photo in 2019" class="top-img" style="margin-bottom: -8px;">
+
+  <div class="page-head">
+    <h1>{{ page.title }}</h1>
+  </div>
+</div>
+
+{{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,8 @@
 layout: default
 ---
 
+{% assign lang = page.lang | default: "ja" %}
+
 <div class="page-head">
   <h1>{{ page.title }}</h1>
 </div>

--- a/english.md
+++ b/english.md
@@ -26,19 +26,24 @@ lang: en
   <p>In 2018, we accepted 12 projects (14 individuals) out of 105 applications. 6 of the creators were certified as Mitou Junior Super Creator. The presentation videos and full information are available <a href="/projects/2018">here</a>.</p>
 
   <h2>Supporters and Sponsors</h2>
-  <p>Mitou Junior is officially recognized and supported by the Ministry of Education, Culture, Sports, Science and Technology, and the Ministry of Economy, Trade and Industry. And we have 10+ financial and in-kind sponsors.</p>
-  <div class="sponsors-list-supporter">
-    <a href="https://www.mext.go.jp/" target="_blank">
-      <div class="sponsor-supporter sponsor-one">
-	<img src="/assets/img/sponsors/mext.png" alt="文部科学省" class="sponsor-img">
-      </div>
-    </a>
-    <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
-      <div class="sponsor-supporter sponsor-one">
-	<img src="/assets/img/sponsors/meti.png" alt="経済産業省" class="sponsor-img">
-      </div>
-    </a>
-  </div>
+  <p>Mitou Junior is officially recognized and supported by the Ministry of Education, Culture, Sports, Science and Technology, and the Ministry of Economy, Trade and Industry. Also we have 10+ financial and in-kind sponsors.</p>
+</div>
+
+<div class="sponsors-list-supporter">
+  <a href="https://www.mext.go.jp/" target="_blank">
+    <div class="sponsor-supporter sponsor-one">
+      <img src="/assets/img/sponsors/mext.png" alt="Ministry of Education, Culture, Sports, Science and Technology" class="sponsor-img">
+    </div>
+  </a>
+  <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
+    <div class="sponsor-supporter sponsor-one">
+      <img src="/assets/img/sponsors/meti.png" alt="Ministry of Economy, Trade and Industry" class="sponsor-img">
+    </div>
+  </a>
 </div>
 
 {% include sponsors.html %}
+{% include collaborators.html %}
+
+{% include contact.html %}
+

--- a/english.md
+++ b/english.md
@@ -1,76 +1,44 @@
 ---
-layout: post
+layout: english
 title: What is Mitou Jr?
+lang: en
 ---
 
-## What's this?
-It is a half-year-long program for talented and innovative creators and programmers under 17 in Japan. The program was founded in 2016 by <a href="https://www.mitou.org/">Mitou Foundation</a>, and has been supported by companies and organizations. which offers the following benefits.
+<div class="post">
+  <h2>What's this?</h2>
+  <p>It is a half-year-long program for talented and innovative creators and programmers under 17 in Japan. The program was founded in 2016 by <a href="https://www.mitou.org/">Mitou Foundation</a>, and has been supported by companies and organizations. which offers the following benefits.</p>
 
-### Mentoring
-Creators will be able to learn from mentors and other Mitou graduates who are at the forefront of technology.
+  <h3>Mentoring</h3>
+  <p>Creators will be able to learn from mentors and other Mitou graduates who are at the forefront of technology.</p>
 
-### Financial Support
-Each group will be eligible to receive up to 500K yen  (almost equivalnt of $4600)  as funding for development.
+  <h3>Financial Support</h3>
+  <p>Each group will be eligible to receive up to 500K yen  (almost equivalnt of $4600)  as funding for development.</p>
 
-### Place to develop
-If necessary, places to develop will be provided.
+  <h3>Place to develop</h3>
+  <p>If necessary, places to develop will be provided.</p>
 
-### Certified as Mitou Junior Super Creators
-Creators who have achieved outstanding results are certified as Mitou Junior Super Creators. They're eligible to apply for Admission Office Entrance Examinations of Keio University SFC and Tokyo Metropolitan University.
+  <h3>Certified as Mitou Junior Super Creators</h3>
+  <p>Creators who have achieved outstanding results are certified as Mitou Junior Super Creators. They're eligible to apply for Admission Office Entrance Examinations of Keio University SFC and Tokyo Metropolitan University.</p>
 
-## Past Projects
-In 2019, we accepted 13 projects (17 individuals) out of 127 applications. 9 of the creators were certified as Mitou Junior Super Creator. The presentation videos and full information are available <a href="/projects/2019">here</a>.
+  <h2>Past Projects</h2>
+  <p>In 2019, we accepted 13 projects (17 individuals) out of 127 applications. 9 of the creators were certified as Mitou Junior Super Creator. The presentation videos and full information are available <a href="/projects/2019">here</a>.</p>
 
-In 2018, we accepted 12 projects (14 individuals) out of 105 applications. 6 of the creators were certified as Mitou Junior Super Creator. The presentation videos and full information are available <a href="/projects/2018">here</a>.
+  <p>In 2018, we accepted 12 projects (14 individuals) out of 105 applications. 6 of the creators were certified as Mitou Junior Super Creator. The presentation videos and full information are available <a href="/projects/2018">here</a>.</p>
 
-<h2>Supporting Public Organizations</h2>
-Mitou Junior is officially recognized and supported by the Ministry of Education, Culture, Sports, Science and Technology, and the Ministry of Economy, Trade and Industry.
-<div class="sponsors-list-supporter">
-  <a href="https://www.mext.go.jp/" target="_blank">
-    <div class="sponsor-supporter sponsor-one">
-      <img src="/assets/img/sponsors/mext.png" alt="文部科学省" class="sponsor-img">
-    </div>
-  </a>
-  <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
-    <div class="sponsor-supporter sponsor-one">
-      <img src="/assets/img/sponsors/meti.png" alt="経済産業省" class="sponsor-img">
-    </div>
-  </a>
+  <h2>Supporters and Sponsors</h2>
+  <p>Mitou Junior is officially recognized and supported by the Ministry of Education, Culture, Sports, Science and Technology, and the Ministry of Economy, Trade and Industry. And we have 10+ financial and in-kind sponsors.</p>
+  <div class="sponsors-list-supporter">
+    <a href="https://www.mext.go.jp/" target="_blank">
+      <div class="sponsor-supporter sponsor-one">
+	<img src="/assets/img/sponsors/mext.png" alt="文部科学省" class="sponsor-img">
+      </div>
+    </a>
+    <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
+      <div class="sponsor-supporter sponsor-one">
+	<img src="/assets/img/sponsors/meti.png" alt="経済産業省" class="sponsor-img">
+      </div>
+    </a>
+  </div>
 </div>
 
-<h2>Sponsors</h2>
-
-<h3>Gold Sponsor</h3>
-<div class="sponsors-list-gold">
-  {% for sponsor in site.data.sponsors.gold %}
-  <a href="{{ sponsor.url }}" target="_blank">
-    <div class="sponsor-gold sponsor-one">
-      <img src="/assets/img/sponsors/{{ sponsor.img }}" alt="{{ sponsor.name }}" class="sponsor-img">
-    </div>
-  </a>
-  {% endfor %}
-</div>
-
-<h3>Silver Sponsor</h3>
-<div class="sponsors-list-silver">
-  {% for sponsor in site.data.sponsors.silver %}
-  <a href="{{ sponsor.url }}" target="_blank">
-    <div class="sponsor-silver sponsor-one">
-      <img src="/assets/img/sponsors/{{ sponsor.img }}" alt="{{ sponsor.name }}" class="sponsor-img">
-    </div>
-  </a>
-  {% endfor %}
-</div>
-
-<h3>Bronze Sponsor</h3>
-<div class="sponsors-list-bronze">
-  {% for sponsor in site.data.sponsors.bronze %}
-  <a href="{{ sponsor.url }}" target="_blank">
-    <div class="sponsor-bronze sponsor-one">
-      <img src="/assets/img/sponsors/{{ sponsor.img }}" alt="{{ sponsor.name }}" class="sponsor-img">
-    </div>
-  </a>
-  {% endfor %}
-</div>
-
-
+{% include sponsors.html %}

--- a/index.md
+++ b/index.md
@@ -115,33 +115,8 @@ layout: default
 </section>
 
 {% include sponsors.html %}
-
-<section id="supporters">
-  <h2>後援</h2>
-  <div class="sponsors-list-supporter">
-    <a href="https://www.mext.go.jp/" target="_blank">
-      <div class="sponsor-supporter sponsor-one">
-        <img src="/assets/img/sponsors/mext.png" alt="文部科学省" class="sponsor-img">
-      </div>
-    </a>
-    <a href="https://www.meti.go.jp/" class="sponsor-supporter sponsor-one" target="_blank">
-      <div class="sponsor-supporter sponsor-one">
-        <img src="/assets/img/sponsors/meti.png" alt="経済産業省" class="sponsor-img">
-      </div>
-    </a>
-  </div>
-</section>
-
-<section id="collaborators">
-  <h2>協力団体</h2>
-  <div class="sponsors-list-clb">
-    {% for c in site.data.collaborators %}
-    <a href="{{c.url}}" class="sponsor-clb sponsor-one" target="_blank">
-      <img src="/assets/img/sponsors/{{c.img}}" alt="{{c.name}}" class="sponsor-img">
-    </a>
-    {% endfor %}
-  </div>
-</section>
+{% include supporters.html %}
+{% include collaborators.html %}
 
 <section id="sns" class="pc">
   <h2 class="heading-line">SNS</h2>
@@ -155,14 +130,4 @@ layout: default
   </div>
 </section>
 
-<section id="contact">
-  <h2 class="heading-line">お問い合わせ</h2>
-  <p></p>
-
-  <i class="fas fa-envelope green" style="font-size:36px;"></i><br>
-  <a href="mailto:jr@mitou.org">jr@mitou.org</a>
-
-  <p>お返事が遅くなる場合もありますが、ご了承ください。<br>チラシ配布にご協力頂ける方は<a href="/flyer">コチラ</a>からご請求をお願い致します。
-  </p>
-  <a href="/q-box" class="button">匿名質問箱はこちら</a>
-</section>
+{% include contact.html %}


### PR DESCRIPTION
@ukkari @yuki384 This PR enables to internationalize shared section between Top and English pages by using dictionary, partial,  and layout.

By I18n we could get one more appealing point for prospective and existing sponsors, supporters, and collaborators that we can promote you in English page. 🗣✨ 🌐

## Sample screenshot of Sponsors section in English

![image](https://user-images.githubusercontent.com/155807/87214131-15053f00-c365-11ea-91ee-2037bede1b19.png)


