### PR TITLE
add scroll-snap to avoid conflict with header

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -499,6 +499,7 @@ footer{
   h3 {
     margin-top: 80px;
   }
+  scroll-snap-type: y proximity;
 }
 .project{
   //border-bottom: solid 1px $lightgray;
@@ -512,6 +513,14 @@ footer{
 
   display: flex;
   flex-direction: column;
+
+  // scroll-margin-top equals to header height
+  scroll-margin-top: 80px;
+  @media screen and (max-width: $header-phone) {
+    scroll-margin-top: 60px;
+  }
+  scroll-snap-align: center;
+
   h4{
     font-size: .8em;
     margin: .1em;


### PR DESCRIPTION
fixed 未踏ジュニアの最終成果報告会のページで個別プロジェクトへのURLで表示した時に肝心のタイトルにツールバーがかぶる