### PR TITLE
/schedule ページの画像幅の修正

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -4,7 +4,7 @@ title: 採択後の流れ
 ---
 
 ## スケジュール
-![一年のスケジュール](/assets/img/schedule2021.svg)
+<img src="/assets/img/spinner.svg" data-src="/assets/img/schedule2021.svg" alt="一年のスケジュール" width="100%" class="post-photo lazyload">
 <center><small>
   ※
   昨今の情勢を鑑みて、合宿および成果発表会などのオンライン開催を現在検討しています。

--- a/schedule.md
+++ b/schedule.md
@@ -5,10 +5,10 @@ title: 採択後の流れ
 
 ## スケジュール
 <img src="/assets/img/spinner.svg" data-src="/assets/img/schedule2021.svg" alt="一年のスケジュール" width="100%" class="post-photo lazyload">
-<center><small>
+<small>
   ※
   昨今の情勢を鑑みて、合宿および成果発表会などのオンライン開催を現在検討しています。
-</small></center>
+</small>
 
 ## メンターとのミーティング
 <img src="/assets/img/spinner.svg" data-src="/assets/img/illustration/mtg.svg" alt="ミーティング" width="50%" class="post-photo lazyload">


### PR DESCRIPTION
## Fixed  Issues
- 2021年の画像がカラム幅から飛び出ていた

## 作業前のスクリーンショット
<img src="https://user-images.githubusercontent.com/23429049/108800523-baa8ae00-75d6-11eb-9001-3768e1153ff2.png" alt="モバイル版の画面"  height="300px"/>

<img width="50%" alt="パソコン版の画面" src="https://user-images.githubusercontent.com/23429049/108800519-b7152700-75d6-11eb-9bc3-995eaf4d1fdf.png">


## 作業後
<img src="https://user-images.githubusercontent.com/23429049/108800745-50dcd400-75d7-11eb-8f18-9814c8134d37.png" alt="モバイル版の画面"  height="300px"/>


<img width="50%" alt="パソコン版の画面" src="https://user-images.githubusercontent.com/23429049/108800764-5f2af000-75d7-11eb-805c-90432d14c8f3.png">


