### PR TITLE
直近で起きている YouTube の障害で再生リストが見れなくなっている問題の対処

### DIFF
--- a/about.md
+++ b/about.md
@@ -41,5 +41,5 @@ title: 未踏ジュニアとは
 
 ### 未踏関係者インタビュー
 未踏関係者に『**なんで未踏?**』という質問をしてみました。未踏について一歩深く知るキッカケになれば嬉しいです <i class="far fa-laugh-squint" aria-hidden="true"> <i class="far fa-thumbs-up" aria-hidden="true" />
-<div class="youtube"><iframe width="779" height="438" src="https://www.youtube.com/embed/videoseries?list=PLNObH2jlC6leiUTypiJYO2zUcwBg7M0Bg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>
+<div class="youtube"><iframe width="779" height="438" src="https://www.youtube.com/embed/playlist?list=PLNObH2jlC6leiUTypiJYO2zUcwBg7M0Bg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>
 <a href="https://www.youtube.com/playlist?list=PLNObH2jlC6leiUTypiJYO2zUcwBg7M0Bg&disable_polymer=true" class="button">YouTubeで視聴する</a>


### PR DESCRIPTION
すぐ治ると思いますが、しばらく治らなかった時のために一応 PR 作っておきます

YouTube の再生リストの埋め込みプレーヤー (embed/videoseries) が見れなくなっている模様
[![Image from Gyazo](https://i.gyazo.com/597756427f42392ce7c10901b66e1d55.gif)](https://gyazo.com/597756427f42392ce7c10901b66e1d55)

未踏ジュニアチャンネルだけでなく他のチャンネルでも同様の現象が起きていることを確認
修正後の URL (embed/playlist) では問題なく視聴できます

該当箇所はリポジトリ検索した限りここだけでした
[![Image from Gyazo](https://i.gyazo.com/567c295690279d82501f7ce2c53a3929.png)](https://gyazo.com/567c295690279d82501f7ce2c53a3929)