### PR TITLE
Split `youtube` column into `promotion` and `final` ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@
 
 それぞれの項目は以下のような内容です。
 ```yml
-- id: 他のIDと重複しないID。例: utips
-  title: プロジェクトのタイトル。例：UTIPS - 家事の情報共有サービス
-  description: プロジェクト概要。例：家事のやり方を共有するWEBサービスを...
-  thumbnail: サムネイル画像。まだ無い場合は「tbu.png」を入力
-  youtube: YouTube動画。「?v=xxxx」の "xxxx" 部分。まだ無い場合は「TBD」を入力
-  year: 採択プロジェクトの年度。例: 2018
-  link: 公式サイトへのリンク（任意）。例: https://visi.dev/
+- id: 他のIDと重複しないID。例: visible
+  title: プロジェクトのタイトル。例：Visible ─ Webアクセシビリティー診断 & 修正提案ツール
+  description: プロジェクト概要。例：VisibleはWebサイトのアクセシビリティーを診断するサービスです。...
+  thumbnail: サムネイル画像。まだ無い場合はコメントアウトしてください。
+  promotion: プロジェクトの PV や紹介動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
+  final: 未踏ジュニア最終成果報告会の動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
+  year: 採択プロジェクトの年度。例: 2020
+  link: 公式サイトへのリンク（任意）。例: https://github.com/visible/visible
   mentor_id: 「mentors.yml」にあるメンターIDを入力。例: yasulab
   creator_ids:
-  - 「cretors.yml」にあるクリエータID。例：mihashi
+  - 「cretors.yml」にあるクリエータID。例：igarashi_ryo
   - 複数名いる場合は、複数記述します
 ```
 

--- a/_data/creators.yml
+++ b/_data/creators.yml
@@ -439,7 +439,6 @@
 - id: fukuzumi_jinshirou
   project_id: voice_commander
   name: 福住 仁志朗
-  youtube: APUTGg6g0hA
   year: 2016
 
 - id: fukuda_kyouko

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -188,6 +188,7 @@
   title: -Flight Fit VR- 「飛行」をテーマに仮想空間で身体を鍛えるVR作品
   description: OculusのVRゴーグルで、美しい景色と音楽の中でリラックスしながら身体を鍛えることができる作品です。３つのミニゲームから構成されており、体幹、腹筋、前腿の筋肉などの筋力向上を期待できます。
   thumbnail: flight_fit_vr.jpg
+  promotion: qLBnTCVsPEk
   final: rIRHwI6EV8E
   link: https://www.oculus.com/experiences/rift/3341393319286540/
   year: 2020

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,15 +1,16 @@
 # Data Template (詳細はREADMEを参照してください)
 #
-#- id: 他のIDと重複しないID。例: utips
-#  title: プロジェクトのタイトル。例：UTIPS - 家事の情報共有サービス
-#  description: プロジェクト概要。例：家事のやり方を共有するWEBサービスを...
-#  thumbnail: サムネイル画像。まだ無い場合は「tbu.png」を入力
-#  youtube: YouTube動画。「?v=xxxx」の "xxxx" 部分。まだ無い場合は「TBD」を入力
-#  year: 採択プロジェクトの年度。例: 2018
-#  link: 公式サイトへのリンク（任意）。例: https://visi.dev/
+#- id: 他のIDと重複しないID。例: visible
+#  title: プロジェクトのタイトル。例：Visible ─ Webアクセシビリティー診断 & 修正提案ツール
+#  description: プロジェクト概要。例：VisibleはWebサイトのアクセシビリティーを診断するサービスです。...
+#  thumbnail: サムネイル画像。まだ無い場合はコメントアウトしてください。
+#  promotion: プロジェクトの PV や紹介動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
+#  final: 未踏ジュニア最終成果報告会の動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
+#  year: 採択プロジェクトの年度。例: 2020
+#  link: 公式サイトへのリンク（任意）。例: https://github.com/visible/visible
 #  mentor_id: 「mentors.yml」にあるメンターIDを入力。例: yasulab
 #  creator_ids:
-#  - 「cretors.yml」にあるクリエータID。例：mihashi
+#  - 「cretors.yml」にあるクリエータID。例：igarashi_ryo
 #  - 複数名いる場合は、複数記述します
 
 
@@ -18,7 +19,8 @@
   title: VRSandbox：誰でも簡単3Dモデリングツール
   description: VRコントローラーを筆とパレットのように使い、直感的に立体物が作れるアプリです。仮想空間や３Dモデルが身近になりましたが、現状で個人が作るのは簡単ではありません。難解なモデリングソフトを使用しなくても簡単に３Dモデリングできます。しゃがむアクションで縮尺が変わり、実物大の建造物に入れます。
   thumbnail: vr_sandbox.png
-  youtube: IKbnWvbEKMo
+  promotion: IKbnWvbEKMo
+  #final
   #link: 
   year: 2021
   mentor_id: bitou_masato
@@ -29,7 +31,8 @@
   title: マークみっけ！for SDGs
   description: SDGsの事を楽しく学べて身近に感じる小学生向けWebアプリです。AIカメラがSDGsと関わっている身の周りにあるマークを教えてくれます。2030年の泣いている子供たちの言葉をヒントにマークを集めると世界が救えます。GIGAスクールで配られたタブレットを持って、学校・家・街でマークを探しに行こう！
   thumbnail: sdgs.png
-  youtube: z_dMy_3UZM8
+  promotion: z_dMy_3UZM8
+  #final
   link: https://www.marksdgs.net/
   year: 2021
   mentor_id: koutake_rina
@@ -40,7 +43,8 @@
   title: Cybotanic：サイボーグ化された植物。
   description: 「植物が生きている」ことを直感的に感じるために、テクノロジーの力で「植物の機能」を拡張するプロジェクトです。植物のイオンチャネルに流れる生体電位を電極で取得し、そこから採れたデータを基に植物を人工筋肉で動かしたり、シンセサイザーを人間と共演します。
   thumbnail: cybotanic.png
-  youtube: TBD
+  #promotion:
+  #final:
   #link: 
   year: 2021
   mentor_id: komuro_maki
@@ -51,7 +55,8 @@
   title: TELPort/テルポート：音波による高速通信プロトコル及び、スピーカーとマイクを介した送受信アプリ
   description: あらゆるデータを複数の周波数と振幅の合成波に変換し、空間と時間を活用した通信を提供するプロトコルです。口頭での伝達が難しいファイルや情報を高速かつ正確に転送し、スマホアプリ化により様々な用途への導入も容易で、費用や特別な設備を必要としません。
   thumbnail: telport.png
-  youtube: TBD
+  #promotion:
+  #final:
   link: https://telport.mugisus.com/app/ # uncommentouted due to the publishing of the application page, there will be one more update when the landing page is ready.
   year: 2021
   mentor_id: shouya_ishimaru
@@ -62,7 +67,8 @@
   title: Curepathy -子供の興味を深めるアプリ-
   description: 小中学生を対象とした能動的な学習を支援するアプリです。ユーザーの評価・タグ・レコメンドエンジンによってユーザーの興味に合った学習コンテンツを提示するほか、着せ替えゲームの要素を取り入れることで楽しく学び続けられる仕組みを提供します。
   thumbnail: curepathy.png
-  youtube: TBD
+  #promotion:
+  #final:
   #link: 
   year: 2021
   mentor_id: nishio_hirokazu
@@ -73,7 +79,8 @@
   title: Researcheck-調べ学習サポートアプリ-
   description: Researcheckは学生の知りたい気持ちを応援する調べ学習アプリです。インターネットには信憑性が低い情報や芸能ニュースによる検索結果の汚染、情報の偏りなどの問題がありますResearcheckは、調べ学習に不適切な情報を警告、除外し対義語を挿入して検索結果の中立性を保ちます。
   thumbnail: researcheck.png
-  youtube: TBD
+  #promotion:
+  #final:
   link: https://researcheck.com/
   year: 2021
   mentor_id: nishio_hirokazu
@@ -84,7 +91,8 @@
   title: Augment － リアルタイム音階推定を用いた音楽ゲーム
   description: ユーザーが弾いている楽器の音をリアルタイムで音階推定し、直感的に楽器を楽しめる音楽ゲームです。タブレットやスマホの楽器アプリでも遊ぶことができます。
   thumbnail: augment.png
-  youtube: DwA0pzPJs14
+  promotion: DwA0pzPJs14
+  #final:
   link: https://twitter.com/Augment_rhythm
   year: 2021
   mentor_id: yasulab
@@ -95,7 +103,8 @@
   title: Haniwa - 家族間タスク共有&報酬提供アプリ
   description: Haniwaは家事などの定期的で意外と重労働な家事に対して、モチベーションアップ+タスク管理を行うアプリケーションです。タスクをクリアするごとに「スター」というアプリ内ポイントを収集し、それによってお小遣いやちょっとした贅沢などを取引することができます。家事以外にも子供の勉強やおつかいなど汎用的なタスクに使用できます
   thumbnail: haniwa.png
-  youtube: FapDQ3aCPCI
+  promotion: FapDQ3aCPCI
+  #final:
   link: https://youtu.be/vKnFXhpF3YU
   year: 2021
   mentor_id: yonetsuji_taizan
@@ -106,7 +115,8 @@
   title: パゲット
   description: パゲットは、全て3Dプリントされた四足歩行ロボットです。モデルデータ、コードを共有する事により、比較的容易にロボット開発ができます。主な目的は、OpenTorqueからヒントを得て、低コストでアクチュエータを開発することでした。
   thumbnail: puguette.png
-  youtube: TBD
+  #promotion:
+  #final:
   #link: 
   year: 2021
   mentor_id: yonetsuji_taizan
@@ -117,7 +127,8 @@
   title: ">>Anyget/掲示板形式小説執筆支援ツール"
   description: SNSや匿名掲示板などを舞台にした、複数の投稿が織りなす物語の執筆を支援するツールです。開発者の執筆経験をもとに、投稿の並び替え、ランダムIDの生成、投稿のコピー&ペーストなど、書き手に嬉しい様々な機能を実装しました。
   thumbnail: anyget.png
-  youtube: TBD
+  #promotion:
+  #final:
   link: https://anyget.github.io/
   year: 2021
   mentor_id: suzuki_ryou
@@ -128,7 +139,8 @@
   title: KillinEngine -マルチプレイ型ゲーム制作エンジン-
   description: キリンエンジンは、仲間と遊びながらオンラインマルチプレイゲームが作れるゲーム制作ツールです。最新のネットワーク技術により、クリエイターたちは一つの仮想空間に召喚されゲームをリアルタイム共同編集することができます。
   thumbnail: killin_engine.png
-  youtube: 72UN95o6MJA
+  promotion: 72UN95o6MJA
+  #final:
   #link: 
   year: 2021
   mentor_id: teramoto_daiki
@@ -139,8 +151,8 @@
   title: Web個展 - Webであることを活かしたオンライン展示形式の模索
   description: 2019年終わりごろから流行し始めたCOVID-19によって、いくつもの現実の個展の開催が中止、延期され、開催する場合も大きな制限を受けることとなりました。それを受け、最近ではWebサイト上で閲覧できる展示も増えましたが、その多くは「現実の個展を再現する」ことに主眼をおいたものであり、あくまでCOVID-19の流行による現実の個展の代替的なものという意味合いが大きいものでした。Web個展ではWebという媒体の特性をより引き出すことに焦点を当て、観覧者がワクワクできるような個展を目指します。
   thumbnail: web-koten.png
-  #thumbnail: tbu.png
-  youtube: TBD
+  #promotion:
+  #final:
   link: https://koten.app
   year: 2021
   mentor_id: seki_yoshifumi
@@ -151,7 +163,8 @@
   title: Birds eye ぴーちゃん　自転車危険予測アプリ
   description: 自転車で行動範囲が広がり始めた小学校高学年のこどもを対象にした自転車危険予測アプリ。登録した危険な交差点に近づくと注意喚起を促します。親子で交通ルールや正しい自転車の乗り方について話せる仕掛けがあり、繰り返し経験することで自分自身と他者の安全を守れる自転車運転を身につけることを目的としています。
   thumbnail: birds_eye.png
-  youtube: TaQ4zNBiwag
+  promotion: TaQ4zNBiwag
+  #final:
   #link: 
   year: 2021
   mentor_id: seki_yoshifumi
@@ -162,7 +175,8 @@
   title: "mock up: 動画編集ソフトウェアフレームワーク"
   description: mock upは動画編集ソフトウェアフレームワークです。動画のレンダリングエンジンと、カスタムフィルター・アニメーションを提供します。mock upを利用すれば、mumlという中間言語を通して動画編集処理を記述することで、簡単なフロントエンドからの呼び出しだけで、動画編集機能を実装することができます。
   thumbnail: mock_up.png
-  youtube: TBD
+  #promotion:
+  #final:
   link: https://github.com/mock-up/mock-up
   year: 2021
   mentor_id: ishii_kakeru
@@ -174,7 +188,7 @@
   title: -Flight Fit VR- 「飛行」をテーマに仮想空間で身体を鍛えるVR作品
   description: OculusのVRゴーグルで、美しい景色と音楽の中でリラックスしながら身体を鍛えることができる作品です。３つのミニゲームから構成されており、体幹、腹筋、前腿の筋肉などの筋力向上を期待できます。
   thumbnail: flight_fit_vr.jpg
-  youtube: rIRHwI6EV8E
+  final: rIRHwI6EV8E
   link: https://www.oculus.com/experiences/rift/3341393319286540/
   year: 2020
   mentor_id: koutake_rina
@@ -185,7 +199,7 @@
   title: GUInfra〜GUIで建てるインフラストラクチャー〜
   description: GUInfraは、クラウドインフラの構成図を自作のグラフ作成ツールを使用して作成でき、トークンを入力することで実際に構築、破棄ができるサービスです。これを使うことにより、クラウドインフラを効率よく学習することができます。
   thumbnail: guinfra.png
-  youtube: ArN9NrsmRs4
+  final: ArN9NrsmRs4
   link: https://guinfra.app/
   year: 2020
   mentor_id: bitou_masato
@@ -196,7 +210,7 @@
   title: ぶらっしゅとーく〜小さな子どものための筆談アプリ〜
   description: これは文字がまだうまく書けない小さな子と耳が聞こえづらいお年寄りがコミュニケーションを取るための筆談アプリです。スマホを使い慣れないお年寄りも簡単に使えるように、操作するためのボタンをなるべく少なくしました。また、イラストを使用することで小さな子が感覚的に使えるようにしました。
   thumbnail: brush_talk.jpg
-  youtube: BeSeF5Exw1s
+  final: BeSeF5Exw1s
   link: https://brushtalk-5c0f3.web.app/
   year: 2020
   mentor_id: nishio_hirokazu
@@ -207,7 +221,7 @@
   title: Spaghetian - 電気と電磁石だけでCPUを自作する！
   description: 三機の電磁石式自作自作CPUを互いにつなげてネットワークにし、その上でオンラインピンポンゲームが動くロマン溢れるプロジェクトです！魔法と見分けがつかなくなった現代のコンピュータテクノロジーの基本を自作することにより、それらが誰でも理解できることを示します。
   thumbnail: spaghetian.jpg
-  youtube: Ue7Sf3bQlps
+  final: Ue7Sf3bQlps
   year: 2020
   link: https://twitter.com/38912Pataro/status/1337322097454981120
   mentor_id: teramoto_daiki
@@ -218,7 +232,7 @@
   title: Color Overlap - 光の三原色RGBを使ったパズルゲーム
   description: 魔法によって「色」を奪われ石にされてしまった人々を救うパズルゲームです。光の３原色RGBの様々な形のブロックをうまく重ねて、王国に色を取り戻そう。Unityで制作しています。
   thumbnail: color_overlap.jpg
-  youtube: _S-EyVp4y1Q
+  final: _S-EyVp4y1Q
   year: 2020
   mentor_id: suzuki_ryou
   creator_ids:
@@ -228,7 +242,7 @@
   title: Poet ~詩人のための創作ツール~
   description: Poet は詩を書く人のための創作ツールで、いつでもどこでも手軽にアイデアを書き留めることができます。日常の言葉を簡単に書き留めることができる環境を通して、ユーザー各々にとっての言葉の宝箱を提供します。
   thumbnail: poet.jpg
-  youtube: PQMZAD6NwYU
+  final: PQMZAD6NwYU
   year: 2020
   mentor_id: ukai_yuu
   creator_ids:
@@ -238,8 +252,8 @@
   title: Visible ─ Webアクセシビリティー診断 & 修正提案ツール
   description: VisibleはWebサイトのアクセシビリティーを診断するサービスです。URLを入力することで問題点を検出しリファレンス付きで提示する他、その修正方法を自動的に提案します。
   thumbnail: visible.png
-  youtube: cwYkmn3oA_o
-  link: https://visi.dev
+  final: cwYkmn3oA_o
+  link: https://github.com/visible/visible
   year: 2020
   mentor_id: yasulab
   creator_ids:
@@ -249,7 +263,7 @@
   title: Mer - 多機能電子リコーダー 
   description: MERはリコーダーを元に、様々な機能を搭載した電子楽器です。発音が簡単なので、初心者でも完成度の高い演奏を体験できます。さらに、気圧センサ、ロータリーエンコーダ 、3D触覚センサを用いた高度な楽器制御が可能です。内蔵FM音源の他に、MIDI出力に対応しているので、ユーザーの好きな音源で演奏ができます。
   thumbnail: mer.png
-  youtube: rQmgwLH8xI0
+  final: rQmgwLH8xI0
   year: 2020
   mentor_id: komuro_maki
   creator_ids:
@@ -259,7 +273,7 @@
   title: SKIMER - LINEで手軽にやること管理
   description: 「SKIMER(スキマー)」は中高生の宿題を管理するためにデザインされたタスク管理アプリです。LINEで友だち追加して簡単に始められます。「クラスのライングループ」から着想を得て、宿題の共有をしたり、宿題の遂行状況を可視化してランキングを作ることで、モチベーションを保てる工夫をしました。そのため、社会性・競争性を取り入れてゲーム感覚で宿題ができます。
   thumbnail: skimer.png
-  youtube: XWLnNYIoe-k
+  final: XWLnNYIoe-k
   link: https://twitter.com/_anharu/status/1344402886264934400
   year: 2020
   mentor_id: ishii_kakeru
@@ -271,7 +285,7 @@
   title: GliderGun - ブラウザOSを簡単に作成できるツール郡
   description: このプロジェクトはLinuxのディストリビューションを簡単に作成できるツール郡を提供します。また、作成するディストリビューションはブラウザを使うことを主な目的としており、このように機能を制限することで様々な恩恵を得ることができます。
   thumbnail: glider_gun.jpg
-  youtube: N23eiKk_808
+  final: N23eiKk_808
   year: 2020
   mentor_id: ishii_kakeru
   creator_ids:
@@ -281,7 +295,7 @@
   title: Align - バッテリー残量からはじまるエモチャット
   description: Alignは手軽にエモいを味わうことができるランダムマッチングチャットアプリです。バッテリー残量が近い人とマッチングし、バッテリー残量が離れると強制的に切断されてしまいます。別れを前提にした新しいチャットアプリで平穏な日常にAlignでちょっと刺激的な体験をお楽しみください。
   thumbnail: align.png
-  youtube: r8WlvrgwB4k
+  final: r8WlvrgwB4k
   year: 2020
   link: https://twitter.com/align_one
   mentor_id: seki_yoshifumi
@@ -293,7 +307,7 @@
   title: critica  - 手軽で直感的なリアクション回収ツール
   description: 「この質問本当にいるの?」「アカウントが必須?」ーー　既存のフォームアプリは、冗長なフォームが作れてしまう、フォームの作成に手間がかかるという課題がありました。criticaはシンプルなリアクションを回収することに特化した、作成者・回答者双方にとって「簡単」なリアクション回収ツールです。数多くのユーザテストをもとに、作成者・回答者双方にとって「簡単」な新しいフォームの形を追求しました。
   thumbnail: critica.jpg
-  youtube: aYajCGOg-eY
+  final: aYajCGOg-eY
   link: https://critica.uno/
   year: 2020
   mentor_id: seki_yoshifumi
@@ -305,7 +319,7 @@
   title: ForceBook - つよつよ自作ノートPC
   description: 筐体から設計・自作し、開発者やゲーマーに使ってほしいノートPCを実現しました。カスタマイズ性を重視してデスクトップ用のパーツを使い、あえてバッテリーを搭載せず電源接続とすることでコンパクトにしました。さらにトラックパッドとしてタッチディスプレイによる新しいインターフェースを考案・実装し、使いやすさにこだわりました。
   thumbnail: forcebook.png
-  youtube: MiBiBzl0ZwU
+  final: MiBiBzl0ZwU
   year: 2020
   mentor_id: yonetsuji_taizan
   creator_ids:
@@ -315,7 +329,7 @@
   title: Levo - 全く新しい近未来的デザインのエアソフトガン
   description: Levoは3DCADと3Dプリンターを最大限活用して開発された近未来的デザインのエアソフトガンです。前例のないデザインでありながら、内部機構の電子制御や極限までコンパクトに設計されたフレームによって機動性を高め、スポーツとしてのサバイバルゲームに特化したエアソフトガンとなっています。
   thumbnail: levo.jpg
-  youtube: MUvjwmUwdsc
+  final: MUvjwmUwdsc
   year: 2020
   mentor_id: yonetsuji_taizan
   creator_ids:
@@ -326,7 +340,7 @@
   title: Rocat ～モデルロケットを使ったSTEM教育～
   description: Rocatは様々なセンサを搭載したプログラミング可能なモデルロケットSTEM教材です。ロケットを組み立てて飛ばして得たデータを考察し合い、楽しく科学や技術への理解を深めていける教材の開発を行っています。
   thumbnail: rocat.png
-  youtube: NXi1hunbMg0
+  final: NXi1hunbMg0
   year: 2020
   mentor_id: shouya_ishimaru
   creator_ids:
@@ -344,7 +358,7 @@
   mentor_id: teramoto_daiki
   description: 編模様(あもーよ)はイラスト手編みを支援するアプリです。オリジナルの編み図を作り、色が変わるまでの数が表示されることで編み間違いを減らすことができます。自分だけの作品を、時間を忘れて編み続けてしまうほど楽しく簡単に作れるようになります。
   thumbnail: amoyo.png
-  youtube: irYt3B7l8yg
+  final: irYt3B7l8yg
   year: 2019
   link: https://amo-yotakenoko.github.io/portfolio/amo-yo.html
 
@@ -355,7 +369,7 @@
   mentor_id: yasulab
   description: DetExploitはWindowsにインストールされている脆弱なソフトウェアを検知し、ユーザーに通知するオープンソースの脆弱性スキャナーです。WMIやレジストリなどのWindows独自機能を使い、高精度なスキャンを実現しています。
   thumbnail: det_exploit.jpg
-  youtube: 0XUID-IQzEk
+  final: 0XUID-IQzEk
   year: 2019
   link: https://detexploit.org/
 
@@ -366,7 +380,7 @@
   mentor_id: nishio_hirokazu
   description: pirkaは、チャットで会話するにつれてあなたの言葉遣いや知識を学習し、個性が出る人工知能です。いわば、「世界に一つの、あなただけのAI」。感情や好みまで自分そっくりのその姿に、きっと親近感が湧きます。
   thumbnail: pirka.png
-  youtube: tZHVhEjqX1g
+  final: tZHVhEjqX1g
   year: 2019
   link: https://pirka-ai.github.io/
 
@@ -377,7 +391,7 @@
   mentor_id: seki_yoshifumi
   description: 生体信号を用いて人間の運動推定をすることを目的に、頭皮脳波・表面筋電位を計測するデバイスの設計・開発と、デバイスを用いた動作推定のアルゴリズム開発を行いました。 頭皮脳波の計測では右上肢の運動推定を行うことに成功し、表面筋電位センサについては実際に筋電義手メーカに採用していただくことができました。
   thumbnail: neulot.png
-  youtube: p_GIhnvDfFI
+  final: p_GIhnvDfFI
   year: 2019
 
 - id: abecobe
@@ -387,7 +401,7 @@
   mentor_id: suzuki_ryou
   description: 正反対な主人公と相棒をゴールにぴったり導くパズルゲーム、abecobeが登場しました。操作は上下左右方向のフリックのみ。２つのキャラクターをぴったりゴールに持っていくだけです。制限時間内にどれだけクリアできるでしょうか？
   thumbnail: abecobe.jpg
-  youtube: B70zjf0Xs6g
+  final: B70zjf0Xs6g
   year: 2019
   link: https://keidaroo.github.io/keidaroo_pages/links/abecobe/
 
@@ -400,7 +414,7 @@
   mentor_id: satou_ayaka
   description: ティッシュペーパーのような日用品を買い忘れてしまい、困った経験はありませんか？ ManageStock はそのような問題を解決するために、在庫を IoT などを活用して管理するアプリケーションです。
   thumbnail: manage_stock.jpg
-  youtube: N1QfbFyjNXg
+  final: N1QfbFyjNXg
   year: 2019
 
 - id: relay_master
@@ -410,7 +424,7 @@
   mentor_id: komuro_maki
   description: センサが埋め込まれた特殊なバトンを持って走るだけで，あらゆる運動を解析するシステムを開発しました。データは専用のwebにアップロードして，あなたの運動をAIで分析・最適化します。“リレーマスター” を利用して，プロに匹敵するパフォーマンスを実現してみませんか？
   thumbnail: relay_master.png
-  youtube: 1ylC6bqWiPg
+  final: 1ylC6bqWiPg
   year: 2019
 
 - id: virtual_presents
@@ -421,7 +435,7 @@
   mentor_id: ishii_kakeru
   description: 仮想世界を彩るためのWebサービスのあり方を模索するプロジェクトです。仮想世界にWeb上から画像を出稿したり、Twitterのようないいね機能を提供することができます。仮想世界とWebという大きく異なる2つの間の架け橋となる概念を提案しました。
   thumbnail: virtual_presents.png
-  youtube: p7KZzZLMLoM
+  final: p7KZzZLMLoM
   year: 2019
 
 - id: edge_guided_anime_characters_generation
@@ -431,7 +445,7 @@
   mentor_id: ukai_yuu
   description: 描きかけの線画を自動で完成させることができる、GANをベースとしたシステムを開発した。これを用いることで初心者でも複雑なイラストを簡単に描くことができるようになる。特に本研究ではアニメの顔画像の生成に焦点をあてた。
   thumbnail: edge_guided_anime_characters_generation.png
-  youtube: OVD5nw1DA5s
+  final: OVD5nw1DA5s
   year: 2019
 
 - id: mallet
@@ -441,7 +455,7 @@
   mentor_id: sasada_kouichi
   description: Malletはスマホやタブレットだけで簡単なアプリを作れる開発環境です。プログラミングに不慣れな方でもブロックを組み合わせてコードを書くことができ、作ったアプリを友達や家族と共有することもできます。
   thumbnail: mallet.png
-  youtube: Tw28ieao9uo
+  final: Tw28ieao9uo
   year: 2019
   link: https://github.com/katsd/mallet-ios
 
@@ -452,7 +466,7 @@
   mentor_id: yonetsuji_taizan
   description: Teaは、仮想経済シミュレーションプラットフォームとそれを使用したゲームです。実際の経済のようなシステムを用意し、ユーザーに自由に貨幣やアイテムの交換をしてもらい、貨幣経済をシミュレーションします。様々な社会システムをシミュレートできます。
   thumbnail: tea.png
-  youtube: rW57i1ZSksA
+  final: rW57i1ZSksA
   year: 2019
 
 - id: fresh_capsule
@@ -462,7 +476,7 @@
   mentor_id: teramoto_daiki
   description: fresh capsuleは、購入した食材の賞味期限を管理する携帯アプリです。 賞味期限が印字されている部分をスマートフォンで撮影すると、賞味期限がアプリ内のリストに落とし込まれます。
   thumbnail: fresh_capsule.jpg
-  youtube: vioFrqxlRXQ
+  final: vioFrqxlRXQ
   year: 2019
 
 - id: smart_vj
@@ -472,7 +486,7 @@
   mentor_id: koutake_rina
   description: スマートフォン1台で誰でも簡単に参加できる体験型のメディアアートです。映像を映し出すPCとスマートフォンがあればスグに遊ぶことが出来ます。直感的な操作で音楽と映像を彩る新しい体験ができ、皆で作品を作り上げる楽しさを味わえます。
   thumbnail: smart_vj.jpg
-  youtube: oGDGH2dmYKA
+  final: oGDGH2dmYKA
   year: 2019
 
 # 2018年度
@@ -484,7 +498,7 @@
   description: 家事のやり方を共有するWEBサービスを開発。ほかの家のやり方を知ることで、よりよい家事をできるように支援。
   comment: Webサービスの開発が初めてでありながら、サービスのコンセプトやデザイン設計、実装や運用、ヒアリング用のテスト環境の構築などがすべて短期間で終えられた点を評価したい。 また、国内や海外のイベントへの積極的展示、言語別にデータを切り変えたヒアリング、ユーザーと対話・協力しながら進めていくスタイルなど、１歩ずつではあるが確実にWebサービスを改善し続けていた点も評価したい。 自分は何をしたいのか」を大切にして今後も１歩ずつ進んでいって欲しい。
   thumbnail: utips.jpg
-  youtube: t8kpeE_sNB0
+  final: t8kpeE_sNB0
   year: 2018
 
 - id: lets_eigo_puzzle
@@ -495,7 +509,7 @@
   description: 小学生が遊びながら英単語を学べる、赤外線通信ブロックとゲームを開発。
   comment: 彼は応募以前から各種展示会で小学生向けデバイスの展示をしており、その経験から思いついたアイデアである。ブースト会議でのジュニアOBとの議論を通じて、当初の計画のLEDマトリクスよりも技術的難易度の高い液晶ディスプレイにチャレンジする決断をした。 解像度が高くなったことによるメモリ消費の増加や、赤外線通信の精度に悩まされながらも、小学生が実際に使えるものを作りあげた。実際のユーザの振る舞いを観察して知見を得るところまで限られた時間でやり遂げたことが素晴らしい。 これからも、どんどん作りたいものを作り、どんどん難しいことにチャレンジして欲しい。
   thumbnail: lets_eigo_puzzle.png
-  youtube: gqkjUVzhSBU
+  final: gqkjUVzhSBU
   year: 2018
 
 - id: smile_meeting_room
@@ -506,7 +520,7 @@
   description: IoTデバイスを用いて会議室予約や会議室内の備品の電源などを制御することで会議室の効率的利用を支援。
   comment: 会議室に設置したセンサーとクラウド上のスケジュール管理サービスを連携させるプロジェクトである。ブースト会議の段階で立てた計画を、期間中に淡々と実行していった。IoTプロジェクトにつきもののトラブルに見舞われつつも、成果報告会までに無事完成させ、実際の会議室に設置する実験を行なった。 安定感のあるプロジェクト進行と成果報告で、会場からは「ぜひインターンに来て欲しい」という声が上がるほどであった。ただ、PMとしては、もっと不確実性にチャレンジするように干渉するべきだったかもしれないなと思っている。 今後もぜひ色々なことにチャレンジしていって欲しい。
   thumbnail: smile_meeting_room.png
-  youtube: Z6_Iw8Hvclk
+  final: Z6_Iw8Hvclk
   year: 2018
 
 - id: vreath
@@ -517,7 +531,7 @@
   description: 誰もが簡単に仮想通貨を入手できる、新しいブロックチェーンを実現するための合意アルゴリズムを開発。
   comment: 新しいブロックチェーンのコンセンサスアルゴリズムを実際に開発し、デモとして体験できるところまで持ってきたことだけで、十分に大きな評価に値する。今後は、Vreath上で動くDAppsを実現するために開発者を巻き込んでいく必要があるが、末神さんが持つ行動力と、ブロックチェーンに関する深い造詣、なによりも圧倒的な情熱があれば、世界をあっと驚かすようなプロジェクトに成長できる可能性を秘めているので、大人の声に惑わされずどんどん開発を進めていってほしい。
   thumbnail: vreath.png
-  youtube: Kq7IuLLNC4Y
+  final: Kq7IuLLNC4Y
   year: 2018
   link: https://github.com/Vreath-core
 
@@ -529,7 +543,7 @@
   description: 使用者の記録や感情を蓄え変化する「森」を基調としたメモ帳アプリのデザインコンセプトを提案
   comment: 箱庭を作るようにメモを画面の中の森に配置するという、既製のメモ帳アプリとは趣を異にするコンセプトを打ち出した。コーディングの学習や制作に十分な時間を割かなかったため実装には至らず、デザイン案の披露だけで終わってしまった。クリエータ個人のプレゼンテーションや図画の作成能力には目を見張るものがあるので、今後実際に動くものを作る能力を習得していければ鬼に金棒である。
   thumbnail: corkboard.png
-  youtube: rDyqAzppN6M
+  final: rDyqAzppN6M
   year: 2018
 
 - id: touch_buy
@@ -542,7 +556,7 @@
   description: VR空間上でECサイトを提供する方法について、様々なプロトタイプを作りながら模索した。
   comment: VR空間では実際の店舗にいかなくても便利に買い物ができるのではないか？」というアイデアは多くの人が考えたことがあるだろう。しかしそのアイデアを実際に行動に移した人は多くない。彼らはVR空間上でのECについて仮説に基づいてプロトタイプを作りながら、その仮説を検証し、新たな仮説によって別のプロトタイプを作ることを3度繰り返した。一つ一つの品質は高くないがVR空間におけるECの可能性と課題を示した点は高く評価できる。今後は開発力を高め世の中に魅力的なプロダクトをどんどん出していってほしい。
   thumbnail: touch_buy.png
-  youtube: luBbuzIb1y0
+  final: luBbuzIb1y0
   year: 2018
 
 - id: robot_soccer
@@ -553,7 +567,7 @@
   description: 強化学習を用いた、ロボットサッカーのプレイヤーの開発。
   comment: 強化学習を用いたシミュレーションを使ってサッカー、しかも二足歩行ロボットでやる、という非常に大きく難しいテーマを選択し、強化学習のフレームを使って、ボールをゴールに運ぶエージェントや二足歩行で目的位置に向かうエージェントのトレーニングに取り組んだ。研究分野として新しい分野であり、色々な知識や実装能力が求められる課題に対して、チャレンジできた事、学習がうまくいかない場合に色々な仮説を立て、それを検証して改善した所については高く評価できる。これらはまだプロジェクト全体の一部でしかないが、ぜひこれからも拡張発展を期待したい。
   thumbnail: robot_soccer.png
-  youtube: 7WnoGTOFRuE
+  final: 7WnoGTOFRuE
   year: 2018
 
 - id: memory_capsule
@@ -564,7 +578,7 @@
   description: 場所に紐付いて、仮想カプセルを埋め、それを掘り出すことのできるSNSを開発。
   comment: 現代人は様々な事をSNSから学び発信し行動へと繋げている。SNSを通じ遠く珍しい体験と触れる我々は、身近にある発見、感動、体験を忘れていないだろうか。そんな問題にも関わらず、それさえもSNSで解決しようというこのプロジェクトは夢に溢れ、ワクワクとさせる。毎週自ら宣言した目標を着実にこなし開発の早かった藤本さんは実際に多くのユーザーテスト、改善を着実に繰り返した。自ら様々な方と交渉し、広げるための手段を着実にこなす行動力もプロジェクトを大きく進められた理由の一つだろう。この経験を通じて多くの人をワクワクさせるプロダクトを広げる未来を強く期待する。
   thumbnail: memory_capsule.png
-  youtube: KgnWDTXwHTY
+  final: KgnWDTXwHTY
   year: 2018
 
 - id: sound_in_the_forest
@@ -575,7 +589,7 @@
   description: 複数のスマートフォン上のウェブブラウザをリアルタイム同期させ、立体音響を実現するシステムの開発。
   comment: 浪川さんは、複数のスマートフォン（スマホ）を音源とする、新しい立体音響の表現に挑戦した。ウェブ技術のみを用いたヘテロジニアス分散リアルタイム同期という難しい課題に最後まで苦戦していたが、最終成果報告会では、持ち込んだ16台のスマホでの演奏、そして来場者のスマホを用いた100台弱での「風の音」のデモを成功させ、会場を沸かせた。目標はさらに大規模な実演ということで、まだ課題は多いが、ぜひ実現して欲しい。
   thumbnail: sound_in_the_forest.png
-  youtube: H7SCFi0fp7g
+  final: H7SCFi0fp7g
   year: 2018
   link: https://twitter.com/73_ch/status/1059065457628434432
 
@@ -587,7 +601,7 @@
   description: 掃除当番に代表される、学校での「当番」の任命や通知をLINE上でできるようにするサービスの開発。
   comment: ソフトウェアを開発するだけでなく、ユーザーのフィードバックをもとに改善のサイクルを回していった点が素晴らしい。　LINE ボットの仕組みは採択時点で既に動作していたため、未踏ジュニアではユーザーがボットを作成できるシステムの開発に挑戦した。実際に使ってもらうには UI を極力シンプルにする必要があったが、身近な課題から出発したアイデアだったため、地に足のついた開発が出来ていた。今後も興味の幅を広げて様々なことにチャレンジして行って欲しい。
   thumbnail: toubans.png
-  youtube: c1R1h4ihcgw
+  final: c1R1h4ihcgw
   year: 2018
   link: https://www.toubans.com/
 
@@ -599,7 +613,7 @@
   description: 写真を写すことで、そこに写った物体の名前を他の言語に翻訳するスマートフォンアプリの開発。
   comment: 河原くんは写して翻訳という写真を写してそのもの名前を表示する、新しい翻訳の形を提示した。最初の提案時よりすでにデモを作ってきており、本人のデザインセンスと毎週の進捗、つくるということに対する好奇心と素早さには毎回驚かされた。画像から言葉という発想も素晴らしく、アンケートを60件取るといった行動力も評価したい。定めた方向性でどう実現するか、そのゴールを描けた時、さらに飛躍的にそして多くの人が惹かれるプロダクトになるだろう。そのセンスと好奇心でどこまでも突き進んでいってほしい。
   thumbnail: camera_translation.png
-  youtube: xTZ4oi6sttA
+  final: xTZ4oi6sttA
   year: 2018
 
 - id: life_watcher
@@ -610,7 +624,7 @@
   description: スマートウォッチ上で動作する、急変する持病を持つ人を助ける警報アプリの開発。
   comment: 武藤君は自身の持つアレルギーにおける緊急時の対応の難しさと重要性について問題意識をもって、スマートウオッチを用いた異常状態の監視システムの可能性を検討したり、緊急事態におけるアラートを飛ばす仕組みについて検討を行い、いくつかのアプリを試作し、実験を行った。アプリ実装の経験はなかったが、新しい技術に対して勉強を行って、実装を進めるという所が出来ていた事、難しい領域に対して確固とした問題意識をもって取り組めた事は評価に値する。ぜひこれからも色々な視点を持って様々な課題に取り組んでみてほしい。
   thumbnail: life_watcher.png
-  youtube: srA90rwohUA
+  final: srA90rwohUA
   year: 2018
 
 # 2017年度
@@ -623,7 +637,7 @@
   description: カラオケで歌った曲、見た映画等の経験に基づいて、AppleMusicから曲を推薦する新しい仕組みのiOSアプリを開発
   comment: 昔聴いていた曲をあまり聴かなくなったのでは、という問題意識から思い出から音楽を聴くサービスを作ろうというプロジェクト。理想をどのようにプロダクトに落とし込んでいくか、そしてどのように作るかということを実地で学んでいた。リリースをまで到達できなかったので、そこは今後の課題としてもらいたい。今回の体験を活かして世の中を変えていくようなサービスを作ることを作り出していくことを期待する。
   thumbnail: music_reminder.png
-  youtube: gfrleUVHGZs
+  final: gfrleUVHGZs
   year: 2017
 
 - id: papa
@@ -636,7 +650,7 @@
   description: PaPaという、学校での円滑な情報伝達を支援し、日本のIT教育に寄与することを目指したWEBアプリケーションを開発。
   comment: 自分たちが通う学校のITシステムの現状に課題を感じ、その課題を解決するサービスを作りたいというプロジェクト。ほぼプログラミング未経験の状態から技術力を高め、実際にクラスの人々に使ってもらい、フィードバックを得て改善するプロセスを進めることができていた。今後はより技術力を高めながら、今回の体験を活かして世の中を変えていくようなサービスを作ることを作り出していくことを期待する。
   thumbnail: papa.png
-  youtube: FSfQnk2evnY
+  final: FSfQnk2evnY
   year: 2017
 
 - id: anki_cookie
@@ -647,7 +661,7 @@
   description: WEBクイズで頑張って覚えた漢字や単語がクッキーに焼かれ、暗記学習のモチベーションアップを支援するシステムを開発。
   comment: 自分自身の、「海外にいると漢字を学ぶモチベーションを保ちにくい」という経験に基づいて、オンラインの漢字テストでがんばって覚えた漢字をレーザーカッターを利用してクッキーに焼くことで、楽しく漢字を学べるシステム「暗記クッキー」を開発した。時間が限られている中で、最低限、動く形まで持ってきたことは評価できるので、今後もこの非常に良いアイデアの可能性を広げることにチャレンジしてほしい。
   thumbnail: anki_cookie.png
-  youtube: CRvzQtz90RM
+  final: CRvzQtz90RM
   year: 2017
 
 - id: narratica
@@ -658,7 +672,7 @@
   description: 自然言語処理によって、映画脚本のテキスト分析を行い、登場人物の感情変化をもとにストーリーを評価。自分で書いた文章もリアルタイムに感情分析。
   comment: スマホアプリ等の開発経験を持っていた事、ストーリーの解析という難しいテーマに対し形態素解析という技術的なアプローチを提案出来ていた事から採択。期間中にサーバサイドでのシナリオ形態の素解析プログラム、クライアントサイドでの感情グラフ化等を実現し、実際に幾つかのシナリオについて分析する事ができた事を高く評価したい。将来性の高いテーマなので、これからの発展に期待したい。
   thumbnail: narratica.png
-  youtube: 7o0_Q_nBGi4
+  final: 7o0_Q_nBGi4
   year: 2017
 
 - id: savacs
@@ -669,7 +683,7 @@
   description: 老人宅の玄関に、見守り装置を設置し、介護者から見守れるようにするシステム。見守り装置は、カメラ及び各種センサを装備し、サーバーを介してWeb経由で介護者が随時様子を知ることができる。
   comment: 祖父を見守りたいというモチベーションで、マイコンを用いてセンサやカメラデータを取得し、サーバサイドでデータベース化およびグラフ化、さらに機械学習を用いた取得画像の分類を行った。 電子工作、サーバ、クライアントと非常に広範な開発をこなす高い技術力を評価して採択。期待以上のエンジニアリング能力を発揮してくれた。これからもその開発力を色々な所で活かして貰いたい。
   thumbnail: savacs.png
-  youtube: lOrb8nH85qo
+  final: lOrb8nH85qo
   year: 2017
   link: https://blog.yr32.net/post/savacs/
 
@@ -681,7 +695,7 @@
   description: 困っている訪日外国人が、旅行者を助けたい日本人に質問できるアプリケーションを開発。
   comment: 訪日外国人ともっと上手くコミュニケーションをとることで、外国人が抱えるなんらかの問題を解決しようという試みである。プロジェクト開始前から空港でアンケートをとるなど意気込みは十分であった。アプリの方は、初めて触る言語での開発だったが、期間中にコツコツ学び続けてプロトタイプを完成させた。そういう意味では、今回はプロジェクトは彼の自信にも繋がったと思われる。これからも持ち前の行動力を活かしていって欲しい。
   thumbnail: fall_in_friends.png
-  youtube: Xr2Jeb5cf7o
+  final: Xr2Jeb5cf7o
   year: 2017
 
 - id: draw_code
@@ -692,7 +706,7 @@
   description: コードが書かれたブロックをつなげていくだけでサイトが作れ、さらにコードも書けるようになる初学者向けのサービスを開発。
   comment: プログラミング教材は今まさに群雄割拠である。彼は自身の原体験をもとに、テキストプログラミングに移行しやすいブロックプログラミングの形を模索した。今回のプロジェクトで、プログラムの表現方法を考えるだけでなく、実装して実際にユーザに使ってもらったことは高く評価できる。また、彼自身がさらにプログラミングを学ぶことによって、編み出せるアイデアは大いに広がるだろう。今後も時間の許す限り色々な物を作って欲しい。
   thumbnail: draw_code.png
-  youtube: t0Ho0S08hJI
+  final: t0Ho0S08hJI
   year: 2017
   link: https://drawcode.net/
 
@@ -704,7 +718,7 @@
   description: 日本語、英語、中国語の3言語で利用できる、音声認識機能を搭載したキーボード。
   comment: 根本さんは、音声認識機能を持つ「聞くキーボード」を、ラズパイを用いて開発した。日本語だけでなく、英語と中国語のデモを行ったのはファインプレイだった。多くの箇所で既存のソフトウェアやサービスを使っているため、本質的に困難な箇所はないが、うまく組み合わせ、使える状態にして公開できたのは大きく評価できる。欲を言えば、キーボードをより活用する提案ができると良かった。改善すべき点も多いが、それも含め、未踏ジュニア期間に体験したことを糧に今後も活躍して欲しい。
   thumbnail: listenable_keyboard.png
-  youtube: foJCvFcYhv0
+  final: foJCvFcYhv0
   year: 2017
 
 - id: smile_iot
@@ -718,7 +732,7 @@
   description: プログラミング不要でIoTデバイスをカスタマイズできるシステムを開発。
   comment: 書類上は山田さんがチームリーダーだが、実質的には足立さんがメインのプロジェクト。足立さんはIoTデバイスをプログラミングなしで使えるようにすることで、よりIoTの普及した世界が訪れることを目的とし、ソフトウェア開発に挑戦した。残念ながら成果報告会でデモを見ることはできなかったが、Raspberry Piの上でWebサービスを動かし、ユーザはプログラムレスで、人感センサの入力をTweetするなどの設定をブラウザ上で行うことができる。何でも自分でやりたいのか、あまりPMに対して報告・連絡・相談をしてくれなかったのが残念である。
   thumbnail: smile_iot.png
-  youtube: uNES_ZXf8eg
+  final: uNES_ZXf8eg
   year: 2017
 
 - id: vamboo
@@ -730,7 +744,7 @@
   description: 配置したGUI要素を線で繋いでいくことでアプリケーションを作っていけるビジュアルプログラミング言語を開発。
   comment: 大野さんと鈴木さんは二人とも十分な開発経験を既に持っており、期間中はプロダクト開発手法を作りながら学ぶことに終始フォーカスできた。今回開発した「vamboo」をリリースさせ、ユーザーテストも行い、OSS として英語で公開した成果には「未来の当たり前」を感じさせられた。未踏コミュニティをうまく活用して、今後は僕らの理解できない未踏の領域を切り開いて欲しい。
   thumbnail: vamboo.png
-  youtube: fejZIj2K9A8
+  final: fejZIj2K9A8
   year: 2017
   link: https://vamboo.net/
 
@@ -742,7 +756,7 @@
   description: 視力が低下したお年寄りから子どもまでが楽にニュース記事を読めるアプリ。文字の表示の工夫、読み進めた部分のマーキング、視線追跡などの機能を搭載。
   comment: 視力の低下で新聞が読みにくくなった人を助けるアプリを開発しました。開発にあたって、新しいプログラミング言語や視線追跡デバイスの使い方、スライドのデザインなどの技術を楽しみながら学び、自分のものにしていきました。プロジェクトの中盤にはユーザテストを行い、実際の使用者と対話をしながらインタフェースを改良しました。このような進め方は人の役に立つアプリを作るうえで大切です。今回技術的に難しく実現できなかった一部の機能は、今後開発の経験を深めていく中で解決方法を見つけられるでしょう。
   thumbnail: rakuraku_yomiyomi.png
-  youtube: jQA4kApjr8s
+  final: jQA4kApjr8s
   year: 2017
 
 # 2016年度
@@ -754,7 +768,7 @@
   description: Voice Commanderは、声とジェスチャーで操作する新感覚チェスゲームです。 グラフィックにこだわるだけでなく、音声認識によるコマの操作、スマホに表示したマーカーを利用したジェスチャー操作等を組み合わせることで、「かっこよさ」を追求しています。 アニメ「ノーゲーム・ノーライフ」に出てきたチェスから着想を得て開発をすすめました。 それぞれのマスにはプレーヤーが音声認識の際に叫ぶための名前がついていて、テキストファイルを変更することで簡単に名前をカスタマイズすることもできます。
   comment: 声による命令とジェスチャーで、プレイヤーを本物の司令官にしてしまう新感覚のコンピュータチェスを実現しました。 　福住さんはプロジェクト当初から「かっこいいチェスを作る」という目標に一貫してこだわり、画像処理や音声認識、3D グラフィックスなど、目標達成に必要な技術を一つ一つ学習し、自分のものにしていきました。 　チェスという伝統的な遊びを踏襲しながらも、まったく新しいプレイ体験を構築したのは、未踏的な発想力と実装力もさることながら、プロジェクト期間中に PM 陣や協力者から受けた様々な意見や提案にただ流されるのでなく、自分なりに吟味・取捨選択し、適切に開発方針を見定めていった成果だと思います。
   thumbnail: voice_commander.png
-  youtube: APUTGg6g0hA
+  final: APUTGg6g0hA
   year: 2016
 
 - id: smart_pen
@@ -766,7 +780,7 @@
   description: スマートペンは、「勉強する時間を計測してさぼり癖をなくしたい」という思いから開発された、スマートデバイスです。 ペンのグリップ部分に取り付けられた静電容量式タッチセンサを利用することでペンを握っているかを検知し、自動で勉強時間を計測、記録します。 記録した勉強時間のログは、スマートフォンに対応アプリケーションをインストールすることで簡単に見ることができます。
   comment: 「明示的な記録開始動作なしに勉強時間を計測したい」という目的のために、ペンにセンサを内蔵しBLEで通信することを提案したプロジェクトでした。共有の作業場なしで物理的なデバイスを製作する困難の中、短い開発期間でペンとして実用可能なサイズのプロトタイプを完成させました。素晴らしい成果だと思います。今後は商品化という更に高い目標を目指すそうで、きっと多くの学びと成長があることだろうと期待しています。
   thumbnail: smart_pen.png
-  youtube: sdrPyfNJx-4
+  final: sdrPyfNJx-4
   year: 2016
 
 - id: vr_picture_book_maker
@@ -777,5 +791,5 @@
   description: VR絵本メーカーは、 VRで体験できる世界やストーリーを制作するためのスマートフォンアプリケーションです。 物語の世界に入ることができる！大好きなあの人とデートができる！憧れのアーティストのライブにも行けちゃう！誰でも簡単にスマホで観れるVR絵本をつくれます。 ユーザーは背景となる360度画像を選択し、キャラクターや吹き出し、さらに効果音、遷移エフェクトを選択してVR絵本にします。
   comment: ユーザーがVRコンテンツを作れるアプリを作る、という非常に挑戦的なテーマに挑み、実際に自分が体験したかった「銀河鉄道」の様なVRコンテンツが製作できるものに仕上げたのは大変素晴らしいです。 今後はアプリのリリースに向けて、細かいバグ修正やコンテンツの共有機能を実装し、さらにその世界を広げていくことを強く期待します。
   thumbnail: vr_picture_book_maker.png
-  youtube: V3SVBM47jOs
+  final: V3SVBM47jOs
   year: 2016

--- a/_includes/project-details.html
+++ b/_includes/project-details.html
@@ -1,8 +1,8 @@
 <div class="project" id="{{ pj.id }}">
   <h3 class="project-title no-link-decoration"><a href='#{{ pj.id }}'>{{ pj.title }}</a></h3>
 
-  <!-- No credits shown, including mentor, unless create_ids assigned. -->
   {% if pj.creator_ids %}
+  <!-- Show no credits, including mentor, unless create_ids assigned. -->
   <p class="project-name">
     {% for creator_id in pj.creator_ids %}
       {% include creator.html is_simple=true %}
@@ -12,30 +12,20 @@
   </p>
   {% endif %}
 
-  <!--
-       Thumbnail Mode shows image instead of video for better rendering time.
-       This mode is usually fit to often-accessed pages like Top page.
-  -->
-  {% if pj.youtube == 'TBD' and pj.thumbnail == 'tbu.png' %}
-  <img src="/assets/img/spinner.svg" data-src="/assets/img/thumbnails/tbu.png"
-       alt="{{ pj.title }}" class="project-thumbnail lazyload" />
-  {% elsif pj.youtube == 'TBD' %}
-  <!-- TBD is used for project showcases with no PV before the final because no videos recorded then. -->
-  <img src="/assets/img/spinner.svg" data-src="/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}"
-       alt="{{ pj.title }}" class="project-thumbnail lazyload" />
-  {% elsif pj.thumbnail == 'tbu.png' %}
-  <!-- TBU is used for project showcases that thumbnails are currently NOT set yet. -->
-  <div class="youtube">
-    <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
-  </div>
-  {% else %}
-  <!-- Not TBD/TBU means thumbnails and youtube videos are all set. -->
+  {% if pj.thumbnail %}
+  <!-- Show thumbnail image if already set. -->
   <a href="/projects/{{ pj.year }}/{{ pj.id }}">
     <img src="/assets/img/spinner.svg" data-src="/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}"
-         alt="{{ pj.title }}" class="project-thumbnail lazyload" />
+         alt="{{ pj.title }}" class="project-thumbnail lazyload" loading="lazy" />
   </a>
-
+  {% else %}
+  <!-- Show TBD thumbnail image if not ready yet. -->
+  <a href="/projects/{{ pj.year }}/{{ pj.id }}">
+    <img src="/assets/img/spinner.svg" data-src="/assets/img/thumbnails/tbu.png"
+         alt="{{ pj.title }}" class="project-thumbnail lazyload" loading="lazy" />
+  </a>
   {% endif %}
+
   <h4>概要</h4>
   <p class="project-description">{{ pj.description }}</p>
 

--- a/_posts/2021-02-20-abecobe.md
+++ b/_posts/2021-02-20-abecobe.md
@@ -9,9 +9,9 @@ description: "正反対な主人公と相棒をゴールにぴったり導くパ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'abecobe'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "正反対な主人公と相棒をゴールにぴったり導くパ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-align.md
+++ b/_posts/2021-02-20-align.md
@@ -9,9 +9,9 @@ description: "Alignは手軽にエモいを味わうことができるランダ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'align'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Alignは手軽にエモいを味わうことができるランダ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-amoyo.md
+++ b/_posts/2021-02-20-amoyo.md
@@ -9,9 +9,9 @@ description: "編模様(あもーよ)はイラスト手編みを支援するア�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'amoyo'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "編模様(あもーよ)はイラスト手編みを支援するア�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-anki_cookie.md
+++ b/_posts/2021-02-20-anki_cookie.md
@@ -9,9 +9,9 @@ description: "WEBクイズで頑張って覚えた漢字や単語がクッキー
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'anki_cookie'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "WEBクイズで頑張って覚えた漢字や単語がクッキー
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-anyget.md
+++ b/_posts/2021-02-20-anyget.md
@@ -9,9 +9,9 @@ description: "SNSや匿名掲示板などを舞台にした、複数の投稿が
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'anyget'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "SNSや匿名掲示板などを舞台にした、複数の投稿が
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-augment.md
+++ b/_posts/2021-02-20-augment.md
@@ -9,9 +9,9 @@ description: "ユーザーが弾いている楽器の音をリアルタイムで
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'augment'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "ユーザーが弾いている楽器の音をリアルタイムで
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-birds_eye.md
+++ b/_posts/2021-02-20-birds_eye.md
@@ -9,9 +9,9 @@ description: "自転車で行動範囲が広がり始めた小学校高学年の
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'birds_eye'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "自転車で行動範囲が広がり始めた小学校高学年の
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-brush_talk.md
+++ b/_posts/2021-02-20-brush_talk.md
@@ -9,9 +9,9 @@ description: "これは文字がまだうまく書けない小さな子と耳が
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'brush_talk'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "これは文字がまだうまく書けない小さな子と耳が
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-camera_translation.md
+++ b/_posts/2021-02-20-camera_translation.md
@@ -9,9 +9,9 @@ description: "写真を写すことで、そこに写った物体の名前を他
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'camera_translation'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "写真を写すことで、そこに写った物体の名前を他
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-color_overlap.md
+++ b/_posts/2021-02-20-color_overlap.md
@@ -9,9 +9,9 @@ description: "魔法によって「色」を奪われ石にされてしまった
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'color_overlap'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "魔法によって「色」を奪われ石にされてしまった
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-corkboard.md
+++ b/_posts/2021-02-20-corkboard.md
@@ -9,9 +9,9 @@ description: "使用者の記録や感情を蓄え変化する「森」を基調
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'corkboard'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "使用者の記録や感情を蓄え変化する「森」を基調
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-critica.md
+++ b/_posts/2021-02-20-critica.md
@@ -9,9 +9,9 @@ description: "「この質問本当にいるの?」「アカウントが必須?�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'critica'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "「この質問本当にいるの?」「アカウントが必須?�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-curepathy.md
+++ b/_posts/2021-02-20-curepathy.md
@@ -9,9 +9,9 @@ description: "小中学生を対象とした能動的な学習を支援するア
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'curepathy'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "小中学生を対象とした能動的な学習を支援するア
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-cybotanic.md
+++ b/_posts/2021-02-20-cybotanic.md
@@ -9,9 +9,9 @@ description: "「植物が生きている」ことを直感的に感じるため
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'cybotanic'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "「植物が生きている」ことを直感的に感じるため
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-det_exploit.md
+++ b/_posts/2021-02-20-det_exploit.md
@@ -9,9 +9,9 @@ description: "DetExploitはWindowsにインストールされている脆弱な�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'det_exploit'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "DetExploitはWindowsにインストールされている脆弱な�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-draw_code.md
+++ b/_posts/2021-02-20-draw_code.md
@@ -9,9 +9,9 @@ description: "コードが書かれたブロックをつなげていくだけで
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'draw_code'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "コードが書かれたブロックをつなげていくだけで
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-edge_guided_anime_characters_generation.md
+++ b/_posts/2021-02-20-edge_guided_anime_characters_generation.md
@@ -9,9 +9,9 @@ description: "描きかけの線画を自動で完成させることができる
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'edge_guided_anime_characters_generation'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "描きかけの線画を自動で完成させることができる
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-fall_in_friends.md
+++ b/_posts/2021-02-20-fall_in_friends.md
@@ -9,9 +9,9 @@ description: "困っている訪日外国人が、旅行者を助けたい日本
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'fall_in_friends'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "困っている訪日外国人が、旅行者を助けたい日本
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-flight_fit_vr.md
+++ b/_posts/2021-02-20-flight_fit_vr.md
@@ -9,9 +9,9 @@ description: "OculusのVRゴーグルで、美しい景色と音楽の中でリ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'flight_fit_vr'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "OculusのVRゴーグルで、美しい景色と音楽の中でリ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-force_book.md
+++ b/_posts/2021-02-20-force_book.md
@@ -9,9 +9,9 @@ description: "筐体から設計・自作し、開発者やゲーマーに使っ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'force_book'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "筐体から設計・自作し、開発者やゲーマーに使っ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-fresh_capsule.md
+++ b/_posts/2021-02-20-fresh_capsule.md
@@ -9,9 +9,9 @@ description: "fresh capsuleは、購入した食材の賞味期限を管理す�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'fresh_capsule'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "fresh capsuleは、購入した食材の賞味期限を管理す�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-glider_gun.md
+++ b/_posts/2021-02-20-glider_gun.md
@@ -9,9 +9,9 @@ description: "このプロジェクトはLinuxのディストリビューショ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'glider_gun'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "このプロジェクトはLinuxのディストリビューショ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-guinfra.md
+++ b/_posts/2021-02-20-guinfra.md
@@ -9,9 +9,9 @@ description: "GUInfraは、クラウドインフラの構成図を自作のグ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'guinfra'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "GUInfraは、クラウドインフラの構成図を自作のグ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-haniwa.md
+++ b/_posts/2021-02-20-haniwa.md
@@ -9,9 +9,9 @@ description: "Haniwaは家事などの定期的で意外と重労働な家事に
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'haniwa'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Haniwaは家事などの定期的で意外と重労働な家事に
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-killin_engine.md
+++ b/_posts/2021-02-20-killin_engine.md
@@ -9,9 +9,9 @@ description: "キリンエンジンは、仲間と遊びながらオンライン
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'killin_engine'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "キリンエンジンは、仲間と遊びながらオンライン
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-lets_eigo_puzzle.md
+++ b/_posts/2021-02-20-lets_eigo_puzzle.md
@@ -9,9 +9,9 @@ description: "小学生が遊びながら英単語を学べる、赤外線通信
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'lets_eigo_puzzle'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "小学生が遊びながら英単語を学べる、赤外線通信
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-levo.md
+++ b/_posts/2021-02-20-levo.md
@@ -9,9 +9,9 @@ description: "Levoは3DCADと3Dプリンターを最大限活用して開発さ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'levo'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Levoは3DCADと3Dプリンターを最大限活用して開発さ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-life_watcher.md
+++ b/_posts/2021-02-20-life_watcher.md
@@ -9,9 +9,9 @@ description: "スマートウォッチ上で動作する、急変する持病を
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'life_watcher'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "スマートウォッチ上で動作する、急変する持病を
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-listenable_keyboard.md
+++ b/_posts/2021-02-20-listenable_keyboard.md
@@ -9,9 +9,9 @@ description: "日本語、英語、中国語の3言語で利用できる、音�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'listenable_keyboard'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "日本語、英語、中国語の3言語で利用できる、音�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-mallet.md
+++ b/_posts/2021-02-20-mallet.md
@@ -9,9 +9,9 @@ description: "Malletはスマホやタブレットだけで簡単なアプリを
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'mallet'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Malletはスマホやタブレットだけで簡単なアプリを
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-manage_stock.md
+++ b/_posts/2021-02-20-manage_stock.md
@@ -9,9 +9,9 @@ description: "ティッシュペーパーのような日用品を買い忘れて
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'manage_stock'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "ティッシュペーパーのような日用品を買い忘れて
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-mark_sdgs.md
+++ b/_posts/2021-02-20-mark_sdgs.md
@@ -9,9 +9,9 @@ description: "SDGsの事を楽しく学べて身近に感じる小学生向けWe
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'mark_sdgs'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "SDGsの事を楽しく学べて身近に感じる小学生向けWe
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-memory_capsule.md
+++ b/_posts/2021-02-20-memory_capsule.md
@@ -9,9 +9,9 @@ description: "場所に紐付いて、仮想カプセルを埋め、それを掘
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'memory_capsule'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "場所に紐付いて、仮想カプセルを埋め、それを掘
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-mer.md
+++ b/_posts/2021-02-20-mer.md
@@ -9,9 +9,9 @@ description: "MERはリコーダーを元に、様々な機能を搭載した電
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'mer'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "MERはリコーダーを元に、様々な機能を搭載した電
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-mock_up.md
+++ b/_posts/2021-02-20-mock_up.md
@@ -9,9 +9,9 @@ description: "mock upは動画編集ソフトウェアフレームワークで�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'mock_up'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "mock upは動画編集ソフトウェアフレームワークで�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-music_reminder.md
+++ b/_posts/2021-02-20-music_reminder.md
@@ -9,9 +9,9 @@ description: "カラオケで歌った曲、見た映画等の経験に基づい
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'music_reminder'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "カラオケで歌った曲、見た映画等の経験に基づい
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-narratica.md
+++ b/_posts/2021-02-20-narratica.md
@@ -9,9 +9,9 @@ description: "自然言語処理によって、映画脚本のテキスト分析
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'narratica'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "自然言語処理によって、映画脚本のテキスト分析
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-neulot.md
+++ b/_posts/2021-02-20-neulot.md
@@ -9,9 +9,9 @@ description: "生体信号を用いて人間の運動推定をすることを目
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'neulot'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "生体信号を用いて人間の運動推定をすることを目
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-papa.md
+++ b/_posts/2021-02-20-papa.md
@@ -9,9 +9,9 @@ description: "PaPaという、学校での円滑な情報伝達を支援し、�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'papa'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "PaPaという、学校での円滑な情報伝達を支援し、�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-pirka.md
+++ b/_posts/2021-02-20-pirka.md
@@ -9,9 +9,9 @@ description: "pirkaは、チャットで会話するにつれてあなたの言�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'pirka'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "pirkaは、チャットで会話するにつれてあなたの言�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-poet.md
+++ b/_posts/2021-02-20-poet.md
@@ -9,9 +9,9 @@ description: "Poet は詩を書く人のための創作ツールで、いつで�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'poet'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Poet は詩を書く人のための創作ツールで、いつで�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-puguette.md
+++ b/_posts/2021-02-20-puguette.md
@@ -9,9 +9,9 @@ description: "パゲットは、全て3Dプリントされた四足歩行ロボ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'puguette'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "パゲットは、全て3Dプリントされた四足歩行ロボ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-rakuraku_yomiyomi.md
+++ b/_posts/2021-02-20-rakuraku_yomiyomi.md
@@ -9,9 +9,9 @@ description: "視力が低下したお年寄りから子どもまでが楽にニ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'rakuraku_yomiyomi'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "視力が低下したお年寄りから子どもまでが楽にニ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-relay_master.md
+++ b/_posts/2021-02-20-relay_master.md
@@ -9,9 +9,9 @@ description: "センサが埋め込まれた特殊なバトンを持って走る
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'relay_master'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "センサが埋め込まれた特殊なバトンを持って走る
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-researcheck.md
+++ b/_posts/2021-02-20-researcheck.md
@@ -9,9 +9,9 @@ description: "Researcheckは学生の知りたい気持ちを応援する調べ�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'researcheck'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Researcheckは学生の知りたい気持ちを応援する調べ�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-robot_soccer.md
+++ b/_posts/2021-02-20-robot_soccer.md
@@ -9,9 +9,9 @@ description: "強化学習を用いた、ロボットサッカーのプレイヤ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'robot_soccer'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "強化学習を用いた、ロボットサッカーのプレイヤ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-rocat.md
+++ b/_posts/2021-02-20-rocat.md
@@ -9,9 +9,9 @@ description: "Rocatは様々なセンサを搭載したプログラミング可�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'rocat'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Rocatは様々なセンサを搭載したプログラミング可�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-savacs.md
+++ b/_posts/2021-02-20-savacs.md
@@ -9,9 +9,9 @@ description: "老人宅の玄関に、見守り装置を設置し、介護者か
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'savacs'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "老人宅の玄関に、見守り装置を設置し、介護者か
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-skimer.md
+++ b/_posts/2021-02-20-skimer.md
@@ -9,9 +9,9 @@ description: "「SKIMER(スキマー)」は中高生の宿題を管理するた�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'skimer'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "「SKIMER(スキマー)」は中高生の宿題を管理するた�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-smart_pen.md
+++ b/_posts/2021-02-20-smart_pen.md
@@ -9,9 +9,9 @@ description: "スマートペンは、「勉強する時間を計測してさぼ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'smart_pen'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "スマートペンは、「勉強する時間を計測してさぼ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-smart_vj.md
+++ b/_posts/2021-02-20-smart_vj.md
@@ -9,9 +9,9 @@ description: "スマートフォン1台で誰でも簡単に参加できる体�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'smart_vj'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "スマートフォン1台で誰でも簡単に参加できる体�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-smile_iot.md
+++ b/_posts/2021-02-20-smile_iot.md
@@ -9,9 +9,9 @@ description: "プログラミング不要でIoTデバイスをカスタマイズ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'smile_iot'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "プログラミング不要でIoTデバイスをカスタマイズ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-smile_meeting_room.md
+++ b/_posts/2021-02-20-smile_meeting_room.md
@@ -9,9 +9,9 @@ description: "IoTデバイスを用いて会議室予約や会議室内の備品
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'smile_meeting_room'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "IoTデバイスを用いて会議室予約や会議室内の備品
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-sound_in_the_forest.md
+++ b/_posts/2021-02-20-sound_in_the_forest.md
@@ -9,9 +9,9 @@ description: "複数のスマートフォン上のウェブブラウザをリア
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'sound_in_the_forest'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "複数のスマートフォン上のウェブブラウザをリア
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-spaghetian.md
+++ b/_posts/2021-02-20-spaghetian.md
@@ -9,9 +9,9 @@ description: "三機の電磁石式自作自作CPUを互いにつなげてネッ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'spaghetian'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "三機の電磁石式自作自作CPUを互いにつなげてネッ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-tea.md
+++ b/_posts/2021-02-20-tea.md
@@ -9,9 +9,9 @@ description: "Teaは、仮想経済シミュレーションプラットフォー
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'tea'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Teaは、仮想経済シミュレーションプラットフォー
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-telport.md
+++ b/_posts/2021-02-20-telport.md
@@ -9,9 +9,9 @@ description: "あらゆるデータを複数の周波数と振幅の合成波に
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'telport'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "あらゆるデータを複数の周波数と振幅の合成波に
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-toubans.md
+++ b/_posts/2021-02-20-toubans.md
@@ -9,9 +9,9 @@ description: "掃除当番に代表される、学校での「当番」の任命
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'toubans'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "掃除当番に代表される、学校での「当番」の任命
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-touch_buy.md
+++ b/_posts/2021-02-20-touch_buy.md
@@ -9,9 +9,9 @@ description: "VR空間上でECサイトを提供する方法について、様�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'touch_buy'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "VR空間上でECサイトを提供する方法について、様�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-utips.md
+++ b/_posts/2021-02-20-utips.md
@@ -9,9 +9,9 @@ description: "家事のやり方を共有するWEBサービスを開発。ほか
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'utips'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "家事のやり方を共有するWEBサービスを開発。ほか
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-vamboo.md
+++ b/_posts/2021-02-20-vamboo.md
@@ -9,9 +9,9 @@ description: "配置したGUI要素を線で繋いでいくことでアプリケ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'vamboo'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "配置したGUI要素を線で繋いでいくことでアプリケ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-virtual_presents.md
+++ b/_posts/2021-02-20-virtual_presents.md
@@ -9,9 +9,9 @@ description: "仮想世界を彩るためのWebサービスのあり方を模索
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'virtual_presents'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "仮想世界を彩るためのWebサービスのあり方を模索
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-visible.md
+++ b/_posts/2021-02-20-visible.md
@@ -9,9 +9,9 @@ description: "VisibleはWebサイトのアクセシビリティーを診断す�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'visible'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "VisibleはWebサイトのアクセシビリティーを診断す�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-voice_commander.md
+++ b/_posts/2021-02-20-voice_commander.md
@@ -9,9 +9,9 @@ description: "Voice Commanderは、声とジェスチャーで操作する新感
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'voice_commander'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "Voice Commanderは、声とジェスチャーで操作する新感
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-vr_picture_book_maker.md
+++ b/_posts/2021-02-20-vr_picture_book_maker.md
@@ -9,9 +9,9 @@ description: "VR絵本メーカーは、 VRで体験できる世界やストー�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'vr_picture_book_maker'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "VR絵本メーカーは、 VRで体験できる世界やストー�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-vr_sandbox.md
+++ b/_posts/2021-02-20-vr_sandbox.md
@@ -9,9 +9,9 @@ description: "VRコントローラーを筆とパレットのように使い、�
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'vr_sandbox'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "VRコントローラーを筆とパレットのように使い、�
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-vreath.md
+++ b/_posts/2021-02-20-vreath.md
@@ -9,9 +9,9 @@ description: "誰もが簡単に仮想通貨を入手できる、新しいブロ
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'vreath'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "誰もが簡単に仮想通貨を入手できる、新しいブロ
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/_posts/2021-02-20-web_koten.md
+++ b/_posts/2021-02-20-web_koten.md
@@ -9,9 +9,9 @@ description: "2019年終わりごろから流行し始めたCOVID-19によって
 {% assign pj = site.data.projects | where_exp: "pj", "pj.id == 'web_koten'" | first %}
 
 <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-{% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-{% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-{% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+{% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+{% else %}               data-src='/assets/img/thumbnails/tbu.png'
+{% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
 {{ pj.description }}
 
@@ -36,13 +36,21 @@ description: "2019年終わりごろから流行し始めたCOVID-19によって
 <p class="project-comment">{{ pj.comment }}</p>
 {% endif %}
 
-{% if pj.youtube != 'TBD' %}
+{% if pj.promotion %}
 ## 紹介動画
 <div class="youtube">
-  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
 </div>
-<a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-{% endif }
+<a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
+
+{% if pj.final %}
+## 発表動画
+<div class="youtube">
+  <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+</div>
+<a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+{% endif %}
 
 {% include project-navigation.html %}
 

--- a/tasks/upsert_project_pages_by_data.rb
+++ b/tasks/upsert_project_pages_by_data.rb
@@ -19,9 +19,9 @@ projects.each_with_index do |project, index|
     {% assign pj = site.data.projects | where_exp: "pj", "pj.id == '#{project['id']}'" | first %}
 
     <img class='top-img lazyload' src='/assets/img/spinner.svg' alt='サムネイル画像' loading='lazy'
-    {% if pj.thumbnail == "tbu.png" %} data-src='/assets/img/thumbnails/tbu.png'
-    {% else %}                         data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
-    {% endif %}                        style='margin-bottom: 10px; border-radius: 6px;' />
+    {% if pj.thumbnail %}    data-src='/assets/img/thumbnails/{{ pj.year }}/{{ pj.thumbnail }}'
+    {% else %}               data-src='/assets/img/thumbnails/tbu.png'
+    {% endif %}                 style='margin-bottom: 10px; border-radius: 6px;' />
 
     {{ pj.description }}
 
@@ -46,13 +46,21 @@ projects.each_with_index do |project, index|
     <p class="project-comment">{{ pj.comment }}</p>
     {% endif %}
 
-    {% if pj.youtube != 'TBD' %}
+    {% if pj.promotion %}
     ## 紹介動画
     <div class="youtube">
-      <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.youtube }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+      <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.promotion }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
     </div>
-    <a href="https://www.youtube.com/watch?v={{ pj.youtube }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
-    {% endif }
+    <a href="https://www.youtube.com/watch?v={{ pj.promotion }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+    {% endif %}
+
+    {% if pj.final %}
+    ## 発表動画
+    <div class="youtube">
+      <iframe width="560" height="315" class="lazyload" data-src="https://www.youtube.com/embed/{{ pj.final }}?rel=0" frameborder="0" allowfullscreen=""></iframe>
+    </div>
+    <a href="https://www.youtube.com/watch?v={{ pj.final }}" target="_blank" rel="noopener" class="button">YouTube で見る</a>
+    {% endif %}
 
     {% include project-navigation.html %}
 


### PR DESCRIPTION
Fix #85 

CI 通ったらマージしますね 🛠💨✨

> 現在は YouTube 埋め込み動画用のカラム (`youtube: youtube_id`) が１つしかなく、 **現状では発表動画しか個別ページに埋め込められない** 仕様となっているので、発表動画用カラムとは別にPV などのダイジェスト動画用のカラムもあると良さそう 🤔💭💡✨ cc/ @ukkari 
> 
> 📺 PV などのダイジェスト動画の例: https://www.youtube.com/watch?v=72UN95o6MJA
> :octocat: 関連 PR: https://github.com/mitou/jr.mitou.org/pull/84
> 
> あとでイイ感じな仕組みを作っておきますね! 🛠💨✨ 