### PR TITLE
Helpfeelのバナーをサイト上に設置する

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -91,4 +91,7 @@
    ga('create', 'UA-77183423-1', 'auto');
    ga('send', 'pageview');
   </script>
+  
+  <!-- Helpfeel -->
+  <script src="https://helpfeel.com/projects/js/helpfeel-element.js" data-project-name="mitoujr" defer></script>
 </head>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -978,3 +978,8 @@ footer{
   opacity: 1;
   transition: all 500ms;
 }
+
+/* bug fix for Helpfeeel Element */
+.helpfeel-launch-button span {
+  color: inherit;
+}


### PR DESCRIPTION
Helpfeel(未踏ジュニアが利用しているFAQサービス)にはElementと呼ばれるサイト埋め込み機能があります。これを有効化するプルリクです。

こんな感じでどのページからも開くことが出来るようになります。

[![Image from Gyazo](https://i.gyazo.com/4890426ab08eb8d54cbe0b3dad59c559.jpg)](https://gyazo.com/4890426ab08eb8d54cbe0b3dad59c559)

https://user-images.githubusercontent.com/6120593/157467092-be53cf2d-f2fa-449d-843e-48cc80a9a160.mp4


