### PR TITLE
外側の見栄えを変えずにHTMLの構造をh1->pタグに変更した

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -968,12 +968,15 @@ footer{
   }
 }
 .subtitle{
+  font-size: 16px;
   margin: 10px 0;
   font-weight: bold;
 }
 .s-title{
-  font-size: 125%;
+  font-size: 20px;
+  //font-size: 125%;
   margin: 20px 0;
+  font-weight: bold;
 }
 .text-left{
   text-align: left;

--- a/index.md
+++ b/index.md
@@ -30,8 +30,8 @@ this_year: 2022
 </div>
 
 <section id="about">
-  <p class="subtitle">未踏ジュニアとは？</p>
-  <h2 class="s-title">独創的アイデアと卓越した技術を持つ<br>小中高生クリエータ支援プログラム</h2>
+  <h1 class="subtitle">未踏ジュニアとは？</h1>
+  <p class="s-title">独創的アイデアと卓越した技術を持つ<br>小中高生クリエータ支援プログラム</p>
 
   <div class="service flex">
     <div class="service-one">


### PR DESCRIPTION
[Google検索の結果](https://www.google.com/search?q=%E6%9C%AA%E8%B8%8F%E3%82%B8%E3%83%A5%E3%83%8B%E3%82%A2)で未踏ジュニアの説明文が表示されないようなので、HTMLの構造を `h`タグ -> `p` タグにすることでうまく表示されるか確認しています。

## Google 検索で head の meta description より、hタグ直後のpタグが表示され、冒頭の説明文がスキップされている様子
![MitouJr_on_Google](https://user-images.githubusercontent.com/155807/200156407-f1fb2326-9c49-483e-bdb4-e511288b6146.png)
