### PR TITLE
HAKのプレゼン開始位置を修正

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -87,7 +87,7 @@
   thumbnail: hak.webp
   #promotion: 
   final: fw1LFIZz-zo
-  final_start: 8496
+  final_start: 9912
   #link: 
   year: 2022
   mentor_id: komuro_maki


### PR DESCRIPTION
https://jr.mitou.org/projects/2022/hak で埋め込みYouTubeを開いたところ「みちしる兵衛」のプレゼンが始まったので、 `8496` から `9912` に開始位置を修正しました。 参考GIF→ https://gyazo.com/a37532249015f435ee63db506eebf215

`9912` という数値ですが、 https://www.youtube.com/watch?v=fw1LFIZz-zo の概要欄に貼られている `2:45:12 HAK － Hand Action Keyboard － 物理的なタッチを必要としない装着型入力デバイス` という文章中のリンクにカーソルを当てると `t=9912s` と出ていたので、これを採用しました。