### PR TITLE
Fix missing URLs for IPA website renewal:

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -65,4 +65,4 @@
   a: はい、過去にも複数名、高校3年生での採択者がいます。
 
 - q: 18歳以上です。応募できますか？
-  a: 未踏ジュニアは17歳以下が対象となっておりますが、24歳以下が対象の<a href='https://www.ipa.go.jp/jinzai/mitou/portal_index.html'>未踏事業</a>や、年齢制限の無い<a href='https://www.ipa.go.jp/jinzai/advanced/index.html'>未踏アドバンスト</a>・<a href='https://www.ipa.go.jp/jinzai/target/index.html'>未踏ターゲット</a>もあります。ぜひチャレンジしてみてください。
+  a: 未踏ジュニアは17歳以下が対象となっておりますが、24歳以下が対象の<a href='https://www.ipa.go.jp/jinzai/mitou/about.html'>未踏事業</a>や、年齢制限の無い<a href='https://www.ipa.go.jp/jinzai/mitou/advanced/about.html'>未踏アドバンスト</a>・<a href='https://www.ipa.go.jp/jinzai/mitou/target/about.html'>未踏ターゲット</a>もあります。ぜひチャレンジしてみてください。

--- a/about.md
+++ b/about.md
@@ -15,9 +15,9 @@ description: 本ページでは初めての方を対象としたコンテンツ�
 ## 未踏ジュニアとは？
 独創的なアイデア、卓越した技術を持つ17歳以下の小中高生及び高専生を支援するプログラムです。
 
-[未踏事業](https://www.ipa.go.jp/jinzai/mitou/outline.html)という、経産省所管の独立行政法人情報処理推進機構（IPA）が主催している、優秀な25歳以下の若者を支援するプログラムがあります。そして、その未踏卒業生がボランティアで運営しているのが、**未踏ジュニア**です。
+[未踏事業](https://www.ipa.go.jp/jinzai/mitou/about.html)という、経産省所管の独立行政法人情報処理推進機構（IPA）が主催している、優秀な25歳以下の若者を支援するプログラムがあります。そして、その未踏卒業生がボランティアで運営しているのが、**未踏ジュニア**です。
 
-<a href="https://www.ipa.go.jp/jinzai/mitou/outline.html" class="button" target="_blank" rel='noopener'>IPA 未踏事業を見る</a>
+<a href="https://www.ipa.go.jp/jinzai/mitou/about.html" class="button" target="_blank" rel='noopener'>IPA 未踏事業を見る</a>
 
 ## 支援
 ### メンタリングの提供
@@ -38,7 +38,7 @@ description: 本ページでは初めての方を対象としたコンテンツ�
 特に顕著な成果を残したクリエータを、未踏ジュニアスーパークリエータとして認定します。慶應義塾大学SFCや東京都立大学に推薦枠で出願できます。(追記: 東京都立大学の推薦枠は<a href='https://twitter.com/mamoruk/status/1318484847317315584' target="_blank" rel='noopener'>認定不要に緩和</a>されました。詳細は<a href='https://www.tmu.ac.jp/extra/download.html?dd=assets%2Ffiles%2Fdownload%2Fentrance%2F2021_ako_bosyuyoko1.pdf' target="_blank" rel='noopener'>募集要項</a>をご参照ください)
 
 ## 運営団体について
-[一般社団法人未踏](https://www.mitou.org/)という、[未踏事業](https://www.ipa.go.jp/jinzai/mitou/portal_index.html)の卒業生を中心とした団体が運営をしています。未踏ジュニアは、その中のプログラミング教育研究会というグループで取り組んでいる事業となっています。
+[一般社団法人未踏](https://www.mitou.org/)という、[未踏事業](https://www.ipa.go.jp/jinzai/mitou/about.html)の卒業生を中心とした団体が運営をしています。未踏ジュニアは、その中のプログラミング教育研究会というグループで取り組んでいる事業となっています。
 
 ### 未踏関係者インタビュー
 未踏関係者に『**なんで未踏?**』という質問をしてみました。未踏について一歩深く知るキッカケになれば嬉しいです <i class="far fa-laugh-squint" aria-hidden="true"> <i class="far fa-thumbs-up" aria-hidden="true" />

--- a/index.md
+++ b/index.md
@@ -166,7 +166,7 @@ this_year: 2022
   <p></p>
   <a href="https://www.mitou.org/"><img src="/assets/img/spinner.svg" data-src="/assets/img/mitou-foundation.png" alt="一般社団法人未踏" class="lazyload" loading="lazy"></a>
 
-  <p><a href="https://www.mitou.org/">一般社団法人未踏</a> (Mitou Foundation、所在地：東京都渋谷区、代表理事：竹内 郁雄) は、経済産業省所管の独立行政法人情報処理推進機構 (IPA、所在地：東京都文京区、理事長：富田 達夫) の事業である<a href="https://www.ipa.go.jp/jinzai/mitou/portal_index.html">未踏事業</a>の OB/OG や関係者を中心に、起業家やクリエータ等、天才的かつ創造的人材を多角的に支援し、日本横断的なネットワークをつくることで、IT を中心とした日本のイノベーションを加速させることを目的に設立された社団法人です。</p>
+  <p><a href="https://www.mitou.org/">一般社団法人未踏</a> (Mitou Foundation、所在地：東京都渋谷区、代表理事：竹内 郁雄) は、経済産業省所管の独立行政法人情報処理推進機構 (IPA、所在地：東京都文京区、理事長：富田 達夫) の事業である<a href="https://www.ipa.go.jp/jinzai/mitou/about.html">未踏事業</a>の OB/OG や関係者を中心に、起業家やクリエータ等、天才的かつ創造的人材を多角的に支援し、日本横断的なネットワークをつくることで、IT を中心とした日本のイノベーションを加速させることを目的に設立された社団法人です。</p>
 </section>
 
 {% include sponsors.html %}


### PR DESCRIPTION
以下のリニューアルに伴い 404 ページになってしまったリンクを一通り修正しました! 🛠💨✨ CI 通ったらマージしますね 🚀✨

2023/03/31 - IPAウェブサイトリニューアルのお知らせ
https://www.ipa.go.jp/news/2022/announce/topic_20230331.html

> リニューアルに伴い、各ページのURLが変更となりました。
> 各ページへのリンクをブラウザの「お気に入り」「ブックマーク」などに登録されている場合は、新しいURLへの変更をお願いします。


https://user-images.githubusercontent.com/155807/229258129-0fca8474-e87c-4940-a979-f4291caab76c.mp4

cf. https://gyazo.com/942a96391db4209858c76ba124e67fd9