### PR TITLE
Enable to load env variables on `jekyll build`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task test: [:build] do
   options = {
     checks: ['Links', 'Images', 'Scripts', 'OpenGraph', 'Favicon'],
     allow_hash_href:  false,
-    disable_external: true,
+    disable_external: ENV['TEST_EXTERNAL_LINKS'] != 'true',
     enforce_https:    true,
 
     # NOTE: Ignore file, URL, and response as follows

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ end
 
 # Enable 'build' to flush cache files via 'clean'
 task build: [:clean] do
-  system 'bundle exec jekyll build' unless ENV['SKIP_BUILD'] == 'true'
+  system 'JEKYLL_ENV=test bundle exec jekyll build' unless ENV['SKIP_BUILD'] == 'true'
 end
 
 task :clean do

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,7 +35,11 @@
 
   <link rel="stylesheet" href="/assets/css/main.css" />
   <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  {% unless site.env.JEKYLL_ENV == 'test' %}
   <script src="https://kit.fontawesome.com/82f32b9df5.js" crossorigin="anonymous"></script>
+  {% endunless %}
+
   <link rel="shortcut icon" href="/assets/img/favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,500,700&display=swap" rel="stylesheet">
 

--- a/_plugins/custom_plugins.rb
+++ b/_plugins/custom_plugins.rb
@@ -1,0 +1,11 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+# https://gist.github.com/nicolashery/5756478
+module Jekyll
+  class EnvironmentVariables < Generator
+    def generate(site)
+      site.config['env'] = {}
+      site.config['env']['JEKYLL_ENV'] = ENV['JEKYLL_ENV'] || 'development'
+      # Add other environment variables to `site.config` here...
+    end
+  end
+end


### PR DESCRIPTION
外部リンクに対するテストを手軽に実行できるようにしました！
CI では無効にしていて、明示的に実行した場合のみテストするようになっています！ 🔍 ✅ 