### PR TITLE
SNS 共有時に追加のハッシュタグも投稿に含めた (例: HATO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@
   promotion: プロジェクトの PV やデモ動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。(Gif にも対応)
   final: 未踏ジュニア成果報告会の発表動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
   final_start: （任意）final の動画再生の開始時刻を指定できます。成果報告会の直後で使います。(例: 123)
-  year: 採択プロジェクトの年度。例: 2020
   link: 公式サイトへのリンク（任意）。例: https://github.com/visible/visible
+  tags: SNS用のハッシュタグ。例: [a11y, Web, アクセスビリティー]
+  year: 採択プロジェクトの年度。例: 2020
   mentor_id: 「mentors.yml」にあるメンターIDを入力。例: yasulab
   creator_ids:
   - 「cretors.yml」にあるクリエータID。例：igarashi_ryo

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -8,6 +8,7 @@
 #  final: 未踏ジュニア成果報告会の発表動画。YouTubeの「?v=xxx」の "xxx" 部分。無い場合はコメントアウト。
 #  final_start: （任意）final の動画再生の開始時刻を指定できます。成果報告会の直後で使います。(例: 123)
 #  link: 公式サイトへのリンク（任意）。例: https://github.com/visible/visible
+#  tags: SNS用のハッシュタグ。例: [a11y, Web, アクセスビリティー]
 #  year: 採択プロジェクトの年度。例: 2020
 #  mentor_id: 「mentors.yml」にあるメンターIDを入力。例: yasulab
 #  creator_ids:
@@ -23,6 +24,7 @@
 #  #final:       # 成果報告会後に追記する
 #  #final_start: # 成果報告会後に追記する
 #  #link:        # 公式サイトがあれば追記する
+#  #tags:        # ハッシュタグがあれば追記する
 #  year: 
 #  mentor_id: 
 #  creator_ids:
@@ -89,6 +91,7 @@
   #final:       # 成果報告会後に追記する
   #final_start: # 成果報告会後に追記する
   #link:        # 公式サイトがあれば追記する
+  tags: [鉄道, 鉄道模型, Nゲージ]
   year: 2023
   mentor_id: rizumu_sakamoto
   creator_ids:

--- a/tasks/upsert_project_pages_by_data.rb
+++ b/tasks/upsert_project_pages_by_data.rb
@@ -44,7 +44,7 @@ projects.each_with_index do |project, index|
         {% endif %}
       {% endif %}
 
-      <a href="https://twitter.com/intent/tweet?text={{ pj.title }}&via=MitouJr&hashtags=未踏ジュニア&related=MitouJr&lang=jp&url={{ site.url }}/projects/{{ pj.year }}/{{ pj.id }}" class="button" target="_blank" rel="noopener">ツイートする</a>
+      <a href="https://twitter.com/intent/tweet?text={{ pj.title }}&via=MitouJr&hashtags=未踏ジュニア{% if pj.hashtags %},{{ pj.hashtags | join: ','}}{% endif %}&related=MitouJr&lang=jp&url={{ site.url }}/projects/{{ pj.year }}/{{ pj.id }}" class="button" target="_blank" rel="noopener">ツイートする</a>
     </div>
 
     ### クリエータ {#creator}


### PR DESCRIPTION
各プロジェクトの紹介サイトにある「ツイートする」ボタンを押下した際に、任意のハッシュタグを追加できるようになります。例: `tags: [鉄道, 鉄道模型, Nゲージ]`

<img width="853" alt="image" src="https://github.com/mitou/jr.mitou.org/assets/155807/08dd077a-da3e-4c1f-9ae7-31c8f2222ffe">

↑ ココにあるボタンを押下すると、以下のようになります ↓

## Before <-----> After

<img width="1083" alt="image" src="https://github.com/mitou/jr.mitou.org/assets/155807/3a987a22-e377-464a-b9f9-fad7c1df2df5">
