### PR TITLE
Show 'ダウンロードする' button if a given project is linked to GitHub release page

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -191,12 +191,12 @@
 
 - id: code_museum
   title: Code Museum - 読むことだけに特化したソースコードエディタ
-  description: Code Museumは、一般的なエディタからあえて「書く機能」をなくし、「読む機能」に特化したソースコードエディタです。範囲実行やGPTを活用した機能など、様々な「読む機能」があります。このエディタを使うことで、コードを読んでいる時間を短縮し、生産性を上げることができます。<br /><br />このソフトウェアは <a href='https://github.com/waryu-YND/code-museum-release/releases/tag/v1.0.0'>Code Museum release</a> からダウンロードできます。
+  description: Code Museumは、一般的なエディタからあえて「書く機能」をなくし、「読む機能」に特化したソースコードエディタです。範囲実行やGPTを活用した機能など、様々な「読む機能」があります。このエディタを使うことで、コードを読んでいる時間を短縮し、生産性を上げることができます。
   thumbnail: code_museum.webp
   #promotion:   # YouTube上にPVがあれば追記する
   final:       OTjx_q-iI6I   # TODO: 切り抜き動画が出たら更新する
   final_start: 15490
-  #link:        # 公式サイトがあれば追記する
+  link: https://github.com/waryu-YND/code-museum-release/releases/tag/v1.0.0
   year: 2023
   mentor_id: nishio_hirokazu
   creator_ids:

--- a/tasks/upsert_project_pages_by_data.rb
+++ b/tasks/upsert_project_pages_by_data.rb
@@ -38,7 +38,9 @@ projects.each_with_index do |project, index|
 
     <div class='flex'>
       {% if pj.link %}
-        {% if pj.link contains 'github.com' %}
+        {% if pj.link contains 'github.com' and pj.link contains 'releases' %}
+           <a href='{{ pj.link }}' target='_blank' class='button'>ダウンロードする</a>
+        {% elsif pj.link contains 'github.com' %}
            <a href='{{ pj.link }}' target='_blank' class='button'>ソースコードを見る</a>
         {% else %}
            <a href='{{ pj.link }}' target='_blank' class='button'>公式サイトを見る</a>


### PR DESCRIPTION
`github.com` ドメインにリンクしている場合「ソースコードを見る」というボタンに変わりますが、当該 GitHub リポジトリの `releases` ページ（バイナリなどをダウンロードできるページ）にリンクされている場合は「ダウンロードする」ボタンに変更するようにした PR です。 cc/ @waryu-YND

参考: About releases - GitHub
https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases

リンク先の例: Code Museum
https://github.com/waryu-YND/code-museum-release/releases/tag/v1.0.0

## 左: GitHub Releases へのリンク、右: GitHub Repository へのリンク

<img width="1687" alt="image" src="https://github.com/mitou/jr.mitou.org/assets/155807/10aa2516-1b67-4ed2-b43c-2991056d8af1">
