### PR TITLE
Add test for proceeding schedule like #180

### DIFF
--- a/tests/custom_checks.rb
+++ b/tests/custom_checks.rb
@@ -47,6 +47,7 @@ end
 # e.g. https://github.com/mitou/jr.mitou.org/pull/180
 def check_deadlines
   this_year     = Date.today.year
+  prev_text     = ''
   prev_deadline = "#{this_year}-01-23"
   this_deadline = "#{this_year}-01-24"
 
@@ -59,7 +60,12 @@ def check_deadlines
     # 例: "3. 応募フォームから提案書をアップロードする （2024年4月6日 23:59まで）"
     # 例: "6. 追加インタビュー期間 （2024年5月14日〜5月27日）"
     this_deadline = "#{this_year}-%02d-%02d" % month_and_day.scan(/\d+/)
-    add_failure("This deadline would be wrong in time order: #{node.text}") if prev_deadline > this_deadline
+    add_failure(<<~ERROR_MESSAGE) if prev_deadline > this_deadline
+    This deadline would be inconsistent with previous one:
+      \s prev_deadline: #{prev_text}
+      \s this_deadline: #{node.text}
+    ERROR_MESSAGE
     prev_deadline = this_deadline
+    prev_text     = node.text
   end
 end

--- a/tests/custom_checks.rb
+++ b/tests/custom_checks.rb
@@ -8,6 +8,7 @@ class CustomChecks < ::HTMLProofer::Check
   def run
     check_meta_tags
     check_json_apis if @runner.current_filename == '_site/api.html'
+    check_deadlines if @runner.current_filename == '_site/guideline.html'
   end
 end
 
@@ -40,4 +41,25 @@ def valid_json?(filename)
   true
 rescue JSON::ParserError, TypeError => e
   false
+end
+
+# Check proceeding schedule is correct in time order:
+# e.g. https://github.com/mitou/jr.mitou.org/pull/180
+def check_deadlines
+  this_year     = Date.today.year
+  prev_deadline = "#{this_year}-01-23"
+  this_deadline = "#{this_year}-01-24"
+
+  # Fetch heading nodes like "1. プロジェクトの計画を立てる"
+  @html.search('h3').select{|n| n.text.start_with?(/\d\./)}.each do |node|
+    month_and_day = node.children.last.text.scan(/\d+月\d+日/).last
+    next if month_and_day.nil? # 〆切の無い heading は省略
+
+    # 〆切のある heading の日付（後半の終端日分）が時間軸に沿っているかチェックする
+    # 例: "3. 応募フォームから提案書をアップロードする （2024年4月6日 23:59まで）"
+    # 例: "6. 追加インタビュー期間 （2024年5月14日〜5月27日）"
+    this_deadline = "#{this_year}-%02d-%02d" % month_and_day.scan(/\d+/)
+    add_failure("This deadline would be wrong in time order: #{node.text}") if prev_deadline > this_deadline
+    prev_deadline = this_deadline
+  end
 end


### PR DESCRIPTION
#180 のような矛盾するスケジュールがあればテストで通知する仕組みを実装しました! :robot: ✅ 

```bash
$ bundle exec rake test

...

Running 6 checks (CustomChecks, Favicon, Images, Links, OpenGraph, Scripts) in ["_site"] on *.html files ...

Checking 470 internal links
Checking internal link hashes in 25 files
Ran on 135 files!

For the CustomChecks check, the following failures were found:

* At _site/guideline.html:
  This deadline would be inconsistent with previous one:
    prev_deadline: 6. 追加インタビュー期間 （2024年5月14日〜5月27日）
    this_deadline: 7. 採択結果の通知 （2024年5月26日）

HTML-Proofer found 1 failure!
```