### PR TITLE
CosenseのURLを新しいものに変更

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -115,8 +115,8 @@
 - name: Cosense
   img:  cosense.webp
   type: inkind
-  link:    https://scrapbox.io/
-  link_en: https://scrapbox.io/?lang=en
+  link:    https://cosen.se/product
+  link_en: https://cosen.se/product?lang=en
 
 - name: Helpfeel
   img:  helpfeel.webp

--- a/applications/index.md
+++ b/applications/index.md
@@ -18,7 +18,7 @@ description: 応募書類（提案書）のテンプレートとサンプルを�
   <a href="https://docs.google.com/document/d/1hjDYf2DbFBkXLyrAl9HKKc9sS40XbZ_iN2j-HKZXD9g/copy" class="button" target='_blank' rel='noopener'>Google Docs を使う</a>
 </div>
 
-<div class="note"><small>上記と同じ形式に揃っていれば（つまりタイトルや提案者の氏名、および 1. から 8. までの項目が揃っていれば）、<a href='https://www.notion.so/ja-jp/product'>Notion</a> や <a href='https://scrapbox.io/product?lang=ja'>Cosense</a>、<a href='https://www.apple.com/jp/pages/'>Pages</a> など他ツールから PDF に変換して提出していただいても大丈夫です。</small></div>
+<div class="note"><small>上記と同じ形式に揃っていれば（つまりタイトルや提案者の氏名、および 1. から 8. までの項目が揃っていれば）、<a href='https://www.notion.so/ja-jp/product'>Notion</a> や <a href='https://cosen.se/product?lang=ja'>Cosense</a>、<a href='https://www.apple.com/jp/pages/'>Pages</a> など他ツールから PDF に変換して提出していただいても大丈夫です。</small></div>
 
 <br>
 


### PR DESCRIPTION
https://github.com/mitou/jr.mitou.org/pull/185 の変更に伴い、URLも差し替えました。

* トップのロゴから飛ぶURL
  * https://scrapbox.io に遷移させると、ログイン済みユーザーさんは個別のプロジェクトが開いてしまうため、誤解が生じる可能性がある
  * 環境によらず飛び先が変わらない https://cosen.se/product にしました
* 応募フォームのリンク
  * こちらはリダイレクトするので振る舞いはほぼ同じですが、cosen.seに統一しました
