### PR TITLE
2024年度のプロジェクトMimicのリンクを再表示し、URLを新しいものに更新しました

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -241,7 +241,7 @@
   #final_start: 10997
   final: NQvbnsiSYUw
   final_start: 46
-  #link: "https://mimic-1801b.web.app/#/list"
+  link: "https://mimic.hirodevs.com"
   #tags:        # ハッシュタグがあれば追記する
   year: 2024
   mentor_id: daiki_teramoto


### PR DESCRIPTION
2024年度のプロジェクトMimicのログインフォームを公開しているため、以前非表示にしていただいていたプロジェクトページのリンクを再度表示させていただきました。また、プロジェクトのURLを最近変更したため、あわせて新しいURLに更新しています。ご確認のほど、よろしくお願いいたします。