### PR TITLE
インタビュー目次ではサムネ画像で視認性を高め、個別ページでは共通レイアウトで DRY 化

### DIFF
--- a/_data/interviews.yml
+++ b/_data/interviews.yml
@@ -1,7 +1,11 @@
 - creator: sugano_kaede
   date:    2025/03/06
+  description: |
+    菅野楓さんは、2017年度の未踏ジュニア修了生。映画の脚本をテキスト分析してストーリーを評価する「narratica〜ストーリーコンサルタント〜」というプロジェクトに取り組みました。本インタビューでは、当時の様子について伺います。
 - creator: okamura_arisa
   date:    2024/04/04
+  description: |
+    岡村有紗さんは、2022年度の未踏ジュニア修了生。2人でチームを組んで「Noxicel - 英作文とAIを用いた英単語学習アプリ」というプロジェクトに取り組みました。本インタビューでは、当時の様子について伺います。
 
 # NOTE: Following interviews are written by MITOU Junior organizer
 #       but they need to create an account to read the interviews.

--- a/_layouts/interview.html
+++ b/_layouts/interview.html
@@ -1,0 +1,54 @@
+{% include head.html %}
+
+<body>
+  {% include header.html %}
+
+  <div class="main">
+    <div class="page-head">
+      <h1>{{ page.title }}</h1>
+    </div>
+
+    <div class="post">
+      {% assign creator_id = page.name | remove: '.md' %}
+      {% assign interview  = site.data.interviews | find: 'creator', creator_id  %}
+
+      <img class="top-img lazyload" loading="lazy"
+           style="border-radius: 6px; border-width: 5px; border-style: solid; border-color: #28a13a; margin: 50px auto 30px;"
+             src="/assets/img/spinner.svg" data-src="{{ page.thumbnail }}"
+             alt="{{ page.thumbnail_alt }}"
+           title="{{ page.thumbnail_alt }}">
+
+      {{ interview.description }}
+
+      {{ content }}
+
+      <div align='center' style='margin: 50px auto;'>（了）</div>
+
+      <div align='right' style='font-size: smaller; margin-bottom: 80px;'>
+	公開日：{{ interview.date | date: "%Y年%-m月%-d日"}}<br>
+	文責：風穴 江（<a href='https://x.com/windhole'>@windhole</a>）<br>
+	インタビュー協力：<a href='/mentors/#yohei_yasukawa'>安川 要平</a>、<a href='/mentors/#yu_ukai'>鵜飼 佑</a>
+      </div>
+
+      <div class="tips">
+	成果報告会の発表も公開されておりますので、よければぜひ!
+      </div>
+
+      {% assign creator = site.data.creators | find: 'id', interview.creator  %}
+      {% assign project = site.data.projects | find: 'id', creator.project_id %}
+      <div class='flex'>
+	<a class='button' href='/projects/{{ project.year }}/{{ project.id }}'>成果報告会の発表を見る</a>
+	<a class='button' href='/interviews'>他のインタビューを見る</a>
+      </div>
+
+      <a class='button' href='https://twitter.com/intent/tweet?text={{ page.title | strip_html }}&via=MitouJr&hashtags=未踏ジュニア&related=MitouJr&lang=jp&url=https://jr.mitou.org/interviews/{{ creator.id }}' target="_blank">ツイートする</a>
+
+      <br>
+
+    </div>
+  </div>
+
+  {% include footer.html %}
+</body>
+
+</html>

--- a/interviews/index.md
+++ b/interviews/index.md
@@ -13,23 +13,35 @@ description: 本ページでは、未踏ジュニア修了生のインタビュ�
 
 <br>
 
-<ul class="list-none news-list">
+<div class="projects flex">
   {% for interview in site.data.interviews %}
   {% assign creator = site.data.creators | find: 'id', interview.creator  %}
   {% assign project = site.data.projects | find: 'id', creator.project_id %}
-  <li>
-    <span class="news-pc-date pc-inline-b">{{ interview.date }}</span>
+
+  <div class="project" id="{{ creator.name }}">
+    <h3 class="project-title no-link-decoration">
+      <a href='#{{ creator.name }}'>
+	未踏ジュニア 修了生インタビュー<br>
+	─
+	{{ creator.name }}さん
+	<!--({{ creator.year }}年度)-->
+	<!--<span class="ph-inline-b">- {{ interview.date }}</span>-->
+      </a>
+    </h3>
+
     <a href="/interviews/{{ creator.id }}">
-      未踏ジュニア 修了生インタビュー
-      ─
-      {{ creator.name }}さん
-      <!--({{ creator.year }}年度)-->
-      <!--<span class="ph-inline-b">- {{ interview.date }}</span>-->
+      <img src="/assets/img/spinner.svg" data-src="/assets/img/interviews/{{ interview.creator }}_1.webp"
+           alt="{{ creator.name }}'s Interview" title="{{ creator.name }}'s Interview"
+           class="project-thumbnail lazyload" loading="lazy" />
     </a>
-    <br>
-    <small>採択プロジェクト『<a href='/projects/{{ project.year }}/{{ project.id }}'>{{ project.title }}</a>』</small>
-  </li>
-  {% endfor %}
-</ul>
+
+    <p class="project-description">{{ interview.description }}</p>
+
+    <a href="/interviews/{{ creator.id }}" class="button">インタビューを見る</a>
+  </div>
+ {% endfor %}
+</div>
+
+<br>
 
 <a href="/applications/#story" class="button">他の採択者の体験談を見る</a>

--- a/interviews/okamura_arisa.md
+++ b/interviews/okamura_arisa.md
@@ -1,22 +1,13 @@
 ---
-layout: post
+layout: interview
 title: 未踏ジュニア <br class='ignore-pc'>修了生インタビュー<br> ─ 岡村 有紗さん
+description: |
+  {% assign creator_id = page.name | remove: '.md' %}
+  {% assign interview  = site.data.interviews | find: 'creator', creator_id  %}
+  {{ interview.description }}
 thumbnail: /assets/img/interviews/okamura_arisa_1.webp
-description: 岡村有紗さんは、2022年度の未踏ジュニア修了生。金尾真樹斗さんと2人でチームを組み「Noxicel - 英作文とAIを用いた英単語学習アプリ」というプロジェクトに取り組みました。本ページでは当時の様子について伺った話をまとめています。
+thumbnail_alt: 岡村有紗さんの成果報告会の様子
 ---
-
-<br>
-
-<a href='/projects/2022/noxicel'>
-  <img class="top-img lazyloaded" loading="lazy"
-       style="border-radius: 6px; border-width: 5px; border-style: solid; border-color: #28a13a;"
-        src="/assets/img/interviews/okamura_arisa_1.webp"
-   data-src="/assets/img/interviews/okamura_arisa_1.webp"
-        alt="岡村有紗さんの成果報告会の様子"
-      title="岡村有紗さんの成果報告会の様子">
-</a>
-
-岡村有紗さんは、2022年度の未踏ジュニア修了生。金尾真樹斗さんと2人でチームを組み「[Noxicel - 英作文とAIを用いた英単語学習アプリ](/projects/2022/noxicel)」というプロジェクトに取り組みました。本ページでは当時の様子について伺った話をまとめています。
 
 
 ## 作りたいものが<br class='ignore-pc'>湧き出てくる
@@ -33,7 +24,7 @@ description: 岡村有紗さんは、2022年度の未踏ジュニア修了生。
 
 そういう感じで、何か作ってみたいものが、生活していて割と頻繁に、すごく湧き出てくるタイプだったので、未踏ジュニアに応募する前から、作りたいものを作るのが習慣になっていました。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
       src="/assets/img/interviews/okamura_arisa_2.webp"
  data-src="/assets/img/interviews/okamura_arisa_2.webp"
       alt="立方体の切断という数学の問題を視覚的に理解するためのアプリ"
@@ -110,7 +101,7 @@ description: 岡村有紗さんは、2022年度の未踏ジュニア修了生。
 
 （でも蓋を開けてみたら）逆に集まりすぎて、こちらでお願いする人を選ばないといけないみたいな感じになるぐらい、協力するよと言ってくださる方がいて、そのときは、すごく嬉しかったです。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
       src="/assets/img/interviews/okamura_arisa_3.webp"
  data-src="/assets/img/interviews/okamura_arisa_3.webp"
       alt="生成AIを使った英単語学習アプリの様子"
@@ -155,7 +146,7 @@ description: 岡村有紗さんは、2022年度の未踏ジュニア修了生。
 
 自分の触ってみたい分野が広がると、すごい楽しいので、友だち作りに、ぜひ（笑）。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
       src="/assets/img/interviews/okamura_arisa_4.webp"
  data-src="/assets/img/interviews/okamura_arisa_4.webp"
       alt="2022年度の未踏ジュニア集合写真"
@@ -186,25 +177,3 @@ description: 岡村有紗さんは、2022年度の未踏ジュニア修了生。
 そういうのが、どこまでできるかというか、どこまでデジタルとアナログを融合させることによっていろんなものを進化できるか、みたいなことを考えています。
 
 アナログとデジタルの融合であったりとか、デジタルな技術を、社会に溶け込むような感じで社会実装するか、（それを）どれだけスムーズにできるかみたいなのに今はすごく興味があって、それを今後もやっていけたらいいなと思っています。
-
-<div align='center' style='margin: 50px auto;'>（了）</div>
-
-<div align='right' style='font-size: smaller;'>
-  公開日：2024年4月3日<br>
-  文責：風穴 江（<a href='https://twitter.com/windhole'>@windhole</a>）<br>
-  インタビュー協力：<a href='/mentors/#yohei_yasukawa'>安川 要平</a>、<a href='/mentors/#yu_ukai'>鵜飼 佑</a>
-</div>
-
-<br>
-
-<div class="tips">
-  成果報告会の発表も公開されておりますので、よければぜひ!
-</div>
-
-<div class='flex'>
-  <a class='button' href='/projects/2022/noxicel'>成果報告会の発表を見る</a>
-  <a class='button' href='/applications/#story'>他の採択者の体験談を見る</a>
-  <a class='button' href='https://twitter.com/intent/tweet?text=未踏ジュニア修了生インタビュー ─ 岡村 有紗さん&via=MitouJr&hashtags=未踏ジュニア&related=MitouJr&lang=jp&url=https://jr.mitou.org/interviews/okamura_arisa' target="_blank">ツイートする</a>
-</div>
-
-<br>

--- a/interviews/sugano_kaede.md
+++ b/interviews/sugano_kaede.md
@@ -1,22 +1,14 @@
 ---
-layout: post
+layout: interview
 title: 未踏ジュニア <br class='ignore-pc'>修了生インタビュー<br> ─ 菅野 楓さん
+description: |
+  {% assign creator_id = page.name | remove: '.md' %}
+  {% assign interview  = site.data.interviews | find: 'creator', creator_id  %}
+  {{ interview.description }}
 thumbnail: /assets/img/interviews/sugano_kaede_1.webp
-description: 菅野楓さんは、2017年度の未踏ジュニア修了生。映画の脚本をテキスト分析してストーリーを評価する「narratica〜ストーリーコンサルタント〜」というプロジェクトに取り組みました。本記事では、当時の様子について伺った話をまとめています。
+thumbnail_alt: 菅野さんと narratica〜ストーリーコンサルタント〜
 ---
 
-<br>
-
-<img class="top-img lazyloaded" loading="lazy"
-     style="border-radius: 6px; border-width: 5px; border-style: solid; border-color: #28a13a;"
-      src="/assets/img/interviews/sugano_kaede_1.webp"
- data-src="/assets/img/interviews/sugano_kaede_1.webp"
-      alt="菅野さんと narratica〜ストーリーコンサルタント〜"
-    title="菅野さんと narratica〜ストーリーコンサルタント〜">
-
-菅野楓さんは、2017年度の未踏ジュニア修了生。映画の脚本をテキスト分析してストーリーを評価する「[narratica〜ストーリーコンサルタント〜](/projects/2017/narratica)」というプロジェクトに取り組みました。本記事では、当時の様子について伺った話をまとめています。
-
-<br>
 
 ## 新しいものを学ぶことが<br class='ignore-pc'>楽しかった
 
@@ -39,7 +31,7 @@ U-22プログラミングコンテストの審査員に未踏関係者が何人�
 
 そこで、そのとき持っていたアイデアを、（未踏ジュニアのメンターである）[安川さん](/mentors/#yohei_yasukawa)と[西尾さん](/mentors/#hirokazu_nishio)に相談したところ、「ここをもっとこうすると面白いんじゃないか」みたいなアドバイスをもらいました。この経験が、未踏ジュニアに直結したと思っています。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
      style="border-radius: 6px;"
       src="/assets/img/interviews/sugano_kaede_2.webp"
  data-src="/assets/img/interviews/sugano_kaede_2.webp"
@@ -105,7 +97,7 @@ U-22プログラミングコンテストの審査員に未踏関係者が何人�
 
 それが、未踏ジュニアを経験して自分が一番変わったところかなと思います。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
       src="/assets/img/interviews/sugano_kaede_3.webp"
  data-src="/assets/img/interviews/sugano_kaede_3.webp"
       alt="成果報告会の様子"
@@ -160,7 +152,7 @@ U-22プログラミングコンテストの審査員に未踏関係者が何人�
 
 なぜかというと、未踏ジュニアの期間中、自分が作っているものについて話を聞いてもらう機会がたくさんあるんです。ちょっと進捗が出たらメンターさんに言いますし、合宿では、未踏ジュニアを修了された先輩にも話を聞いてもらえたりします。成果報告会も、もちろん、そうですし。いろんな人に話を聞いてもらって、「これ、いいね」と言ってもらえると、モチベーションになりますし、作っているサービスの力が増すような気がしています。自分がそうだったので、これは本当にお勧めです。
 
-<img class="top-img lazyloaded" loading="lazy"
+<img class="top-img lazyload" loading="lazy"
       src="/assets/img/interviews/sugano_kaede_4.webp"
  data-src="/assets/img/interviews/sugano_kaede_4.webp"
       alt="未踏ジュニア修了式の様子"
@@ -175,30 +167,3 @@ U-22プログラミングコンテストの審査員に未踏関係者が何人�
   </small>
 </div>
 
-<!--
-<div class='youtube'>
-  <iframe src="https://www.youtube.com/embed/okW-GD5xo-4" title="The Big Bang Competition" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
--->
-
-<div align='center' style='margin: 50px auto;'>（了）</div>
-
-<div align='right' style='font-size: smaller;'>
-  公開日：2025年3月6日<br>
-  文責：風穴 江（<a href='https://x.com/windhole'>@windhole</a>）<br>
-  インタビュー協力：<a href='/mentors/#yohei_yasukawa'>安川 要平</a>、<a href='/mentors/#yu_ukai'>鵜飼 佑</a>
-</div>
-
-<br>
-
-<div class="note">
-  成果報告会の発表も公開されておりますので、よければぜひ!
-</div>
-
-<div class='flex'>
-  <a class='button' href='/projects/2017/narratica'>成果報告会の発表を見る</a>
-  <a class='button' href='/applications/#story'>他の採択者の体験談を見る</a>
-  <a class='button' href='https://twitter.com/intent/tweet?text=未踏ジュニア修了生インタビュー ─ 菅野 楓さん&via=MitouJr&hashtags=未踏ジュニア&related=MitouJr&lang=jp&url=https://jr.mitou.org/interviews/sugano_kaede' target="_blank">ツイートする</a>
-</div>
-
-<br>


### PR DESCRIPTION
## 概要
- インタビュー目次ページでは、サムネ画像で視認性を改善
- インタビュー個別ページでは、共通レイアウトで重複コードを削減

### Before <---> After

<img width="1607" height="931" alt="image" src="https://github.com/user-attachments/assets/e068f5ee-d657-49a7-9542-73813f42a286" />

https://jr.mitou.org/interviews/

## 変更内容

### 🎨 UI/UXの改善
- **インタビュー一覧ページ** (`/interviews`)
  - リスト形式からカード形式に変更（プロジェクトページと統一）
  - 各インタビューにサムネイル画像を表示
  - インタビューの概要文を追加表示
  - 「インタビューを見る」ボタンで明確な導線を提供

### 🏗️ 構造的改善
- **新規レイアウトファイル** (`_layouts/interview.html`)
  - インタビュー専用の共通レイアウトを作成
  - フッター情報（公開日、文責、協力者）を一元管理
  - ソーシャルシェアボタンやナビゲーションを統一

### 📊 データ構造の拡充
- **インタビューデータ** (`_data/interviews.yml`)
  - 各インタビューに `description` フィールドを追加
  - 構造化データとして概要を管理

### 🔧 技術的最適化
- `lazyloaded` → `lazyload` クラスの統一
- `thumbnail_alt` 属性の追加によるアクセシビリティ向上
- DRY原則に基づく重複コード削減（各ページから約25行）

## 変更前後の比較

### Before
- シンプルなリスト形式
- 各インタビューページに重複したHTML構造
- 視覚的要素が少ない

### After
- カード形式で視覚的に魅力的
- 共通レイアウトによる一貫性
- サムネイルと説明文で情報量が充実

## 確認項目
- [x] 既存の2つのインタビューページが正常に表示される
- [x] インタビュー一覧ページのレスポンシブ対応
- [x] 画像の遅延読み込みが機能する
- [x] リンクとナビゲーションが正しく動作する

## スクリーンショット
変更後のインタビュー一覧ページは、プロジェクトページと同様のカード形式で統一感のあるデザインになっています。

## 関連情報
- プロジェクトページ（`/projects`）と同様のデザインパターンを採用
- 今後のインタビュー追加が容易になる構造