### PR TITLE
fix: 一部の PDF 内にあるリンクをクリックできない問題の修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,13 @@ jobs:
       with:
         bundler-cache: true
 
+    # 提案書 PDF 内のリンク (_data/application_links.yml) が PDF のテキストと
+    # 照合できるかを検証する。pdftotext を使うため poppler-utils を入れる。
+    - name: 📄 Verify links in application PDFs
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -y -qq poppler-utils
+        bundle exec rake verify_application_links
+
     - name: 🔧 Build & Test
       run: |
         bundle exec rake upsert_project_pages_by_data
@@ -52,7 +59,7 @@ jobs:
       run: |
         COMMIT_MESSAGE=$(git show -s --format=%s HEAD)
         PR_NUMBER=$(echo "$COMMIT_MESSAGE" | sed -nE 's/^Merge pull request #([0-9]+).*/\1/p')
-        
+
         if [ -n "$PR_NUMBER" ]; then
           echo "PR_NUMBER=#$PR_NUMBER" >> $GITHUB_ENV; else
           echo "PR_NUMBER="            >> $GITHUB_ENV

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,12 @@ task(:upsert_project_samples_by_data) { ruby "_tasks/upsert_project_samples_by_d
 desc 'Translate given-year projects with LLM'
 task(:convert_ja2en_by_llm) { ruby "_tasks/convert_ja2en_by_llm.rb" }
 
+desc 'Extract URL candidates from application PDFs (draft for _data/application_links.yml)'
+task(:extract_application_links) { ruby "_tasks/extract_application_links.rb" }
+
+desc 'Verify that links in _data/application_links.yml are found in the PDFs'
+task(:verify_application_links) { ruby "_tests/verify_application_links.rb" }
+
 desc 'Build the site with Jekyll (flushes cache via clean)'
 task(build: [:clean]) { system 'bundle exec jekyll build' unless ENV['SKIP_BUILD'] == 'true' }
 

--- a/_data/application_links.yml
+++ b/_data/application_links.yml
@@ -1,0 +1,169 @@
+# 提案書サンプル (PDF) 内のリンク
+# https://jr.mitou.org/applications/
+#
+# ■ なぜこのファイルが必要か
+#
+# 提案書 PDF の一部は、リンク注釈 (Link Annotation) を持っていない。
+# iLovePDF による圧縮や、macOS の「印刷」経由での書き出しで、注釈が失われるため。
+# 注釈が無いと PDF.js はリンクを復元できず、URL は「ただの文字」として描かれる。
+#
+# さらに、PDF に描かれた文字列は、そのままでは正しい URL にならないことがある。
+#   - 行末で折り返され、2〜3 行に分かれる (例: jellyfish_alert, uminavi)
+#   - URL の途中に空白が入る          (例: fudey の `20120928- a140/`)
+#   - アンダースコアが結合文字として埋め込まれる (例: abecobe)
+#
+# そのため、URL の正しさは「人が PDF を目視して確定し、このファイルに書く」ことで担保する。
+# JavaScript 側は、ここに書かれた URL を PDF のテキストから探して位置を決めるだけを担当する。
+# 自動検出に任せると、404 になる誤ったリンクを貼ってしまう。
+#
+# PDF がリンク注釈を持っている場合は、そちらが優先され、このファイルのリンクは使われない
+# (同じ場所に二重にリンクを貼らない)。つまりここには全 PDF のリンクを書いてよく、
+# 注釈が失われている PDF でだけ、このファイルが効く。
+#
+# ■ 各フィールド
+#
+#   - page:  PDF のページ番号 (1 始まり)
+#   - url:   実際に飛ぶ URL (人が PDF を目視して確定したもの)
+#   - match: 省略可。PDF 上のテキストと照合するための部分文字列。
+#            PDF に描かれた文字が url と異なる場合のみ書く。
+#            照合時は空白・改行を無視するので、折り返しや空白混入のためには不要。
+#
+# ■ 下書きの生成
+#
+#   bundle exec rake extract_application_links
+#
+#   PDF から URL 候補を抽出して下書きを出力する。必ず PDF を目視して確認すること。
+
+- project_id: a9n
+  links:
+    - page: 9
+      url: https://github.com/horizon2038/hss-python
+    - page: 9
+      url: https://github.com/horizon2038/national-flags-scraper
+
+- project_id: abecobe
+  links:
+    - page: 3
+      url: https://youtu.be/eZepKYRDOcE?t=6
+    - page: 7
+      # PDF 上ではアンダースコアが結合文字 (U+0332) として埋め込まれており、
+      # URL 全体では一致しないため、折り返し前の部分文字列で照合する。
+      url: https://docs.google.com/presentation/d/1FhRYgvBehZVVlZIdG-sIAv6jpl_gbHHW5w3f5BvRNn0/edit?usp=sharing
+      match: https://docs.google.com/presentation/d/1FhRYgvBehZVVlZIdG-
+    - page: 7
+      url: https://drive.google.com/open?id=1tjwc9dUcOji3dzkg2haZ2bDwdFjaBbn8
+
+- project_id: amoyo
+  links:
+    - page: 9
+      url: https://twitter.com/search?q=%E7%B7%A8%E3%81%BF%E7%89%A9%E6%94%AF%E6%8F%B4%E3%83%84%E3%83%BC%E3%83%AB&src=typed_query
+    - page: 11
+      url: http://www.nhk.or.jp/sougou/programming/?das_id=D0005180330_00000#in=1632
+    - page: 11
+      url: https://twitter.com/eijitanuma/status/1067986682203430912
+    - page: 12
+      url: https://youtu.be/nk451InsIuM
+    - page: 12
+      url: https://youtu.be/NKCoc6RfqOo
+    - page: 12
+      url: https://youtu.be/IV5UtyGberM
+    - page: 18
+      url: https://www.kodomonokagaku.com/magazine/programmingcontest.php
+    - page: 18
+      url: https://tech.nikkeibp.co.jp/it/article/COLUMN/20140213/536503/?P=11
+
+- project_id: det_exploit
+  links:
+    - page: 1
+      url: https://twitter.com/moppoi5168
+    - page: 5
+      url: https://github.com/moppoi5168/DetExploit
+    - page: 6
+      url: https://moppoi5168.github.io/
+    - page: 6
+      url: https://twitter.com/naogramer/
+    - page: 6
+      url: https://github.com/moppoi5168/
+    - page: 11
+      url: https://www.slideshare.net/ssuser6c19e1/abyss-of-badusb
+
+- project_id: fudey
+  links:
+    - page: 11
+      # PDF 上では `20120928- a140/` と空白が入って描かれている (照合時に空白は無視される)
+      url: https://news.mynavi.jp/techplus/article/20120928-a140/
+
+- project_id: jellyfish_alert
+  links:
+    - page: 9
+      url: https://nice-asp-ef7.notion.site/Building-Jellyfish-Alert-System-using-Drone-and-AI-f5c124e1dedc4b198e3fdce1762e7ac7?pvs=4
+    - page: 9
+      url: https://www.notion.so/Creating-Jellyfish-swarms-prediction-model-968b4eabac194509aabe14a478491db8?pvs=4
+    - page: 9
+      url: https://www.notion.so/Predict-jellyfish-swarms-by-sea-current-934845f94649462fb870217edaf46a8c?pvs=4
+    - page: 9
+      url: https://www.notion.so/Jellyfish-swarms-when-temperature-wall-goes-off-b47698cea26a479e8cb3f02c4e0197df?pvs=4
+
+- project_id: mer
+  links:
+    - page: 5
+      url: http://ewi.akai-pro.jp/ewi5000w/
+    - page: 6
+      url: https://www.roland.com/jp/products/aerophone_ae-10/
+    - page: 6
+      url: https://www.kickstarter.com/projects/888369457/the-recorder-reinvented
+
+- project_id: niwangojs
+  links:
+    - page: 2
+      url: https://github.com/xpadev-net/niwango
+    - page: 3
+      url: https://github.com/xpadev-net/niconicomments/
+    - page: 3
+      url: https://www.npmjs.com/package/@xpadev-net/niconicomments
+    - page: 3
+      url: https://xpadev-net.github.io/niconicomments/sample/
+    - page: 3
+      url: https://github.com/tanbatu/comment-zouryou
+    - page: 3
+      url: https://github.com/nyankomaher/nicotver
+    - page: 3
+      url: https://github.com/RyotaKITA-12/terminalKakeGohan
+    - page: 3
+      url: https://twitter.com/geek_pjt/status/1619640824538746882
+    - page: 3
+      url: https://github.com/geekcamp-vol11-team30/
+    - page: 3
+      url: https://magi-sche.vercel.app/
+    - page: 3
+      url: https://github.com/GiikuCAMPvol1/
+    - page: 4
+      url: https://github.com/xpadev-net/niwango.js
+    - page: 4
+      url: https://xpadev-net.github.io/niconicomments/sample/?video=23
+    - page: 4
+      url: https://xpadev-net.github.io/niconicomments/sample/?video=24
+    - page: 4
+      url: https://twitter.com/search?q=from%3A%40xpadev%20%23%E3%83%8B%E3%83%AF%E3%83%B3%E8%AA%9E&f=live
+
+- project_id: noxicel
+  links:
+    - page: 7
+      url: https://eigo-duke.com/tango/tangoindex.html
+
+- project_id: tactica_note
+  links:
+    - page: 8
+      url: https://tactica-chat.com
+
+- project_id: uminavi
+  links:
+    - page: 8
+      url: https://github.com/sharminrahman/SVIn2?tab=readme-ov-file
+    - page: 17
+      url: https://www.matlabexpo.com/content/dam/mathworks/mathworks-dot-com/images/events/matlabexpo/jp/2023/Evaluation-of-real-world-applicability-of-gps-independent-location-estimation-methods.pdf
+
+- project_id: visible
+  links:
+    - page: 13
+      url: https://wakatime.com/@Ryo

--- a/_includes/render-pdf-by-pdfjs.html
+++ b/_includes/render-pdf-by-pdfjs.html
@@ -35,13 +35,17 @@
     height: auto !important;
     min-height: 0 !important;
     padding: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
     background: #f5f5f5;
     border: 1px solid #ddd;
     border-radius: 4px;
     margin-bottom: 10px;
-    scroll-behavior: smooth;
+    /* clip は「はみ出しを切る」だけで、スクロールできる領域を作らない。
+       1 ページずつ描画してボタンで送るビューアなので、内部スクロールは要らない。
+
+       auto や hidden にすると、canvas の高さの端数 (例 1128.6px) のせいで 1px だけ
+       スクロールできる状態になり、ページを読むためのマウスホイールがそこに吸われる
+       (スクロールが親に伝わらず、ページが動かなくなる)。 */
+    overflow: clip;
   }
   .pdf-page-container {
     position: relative;
@@ -325,35 +329,36 @@
       };
 
       // タッチイベントの処理
-      leftArrow.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
+      //
+      // touchstart では preventDefault しない。矢印はタップ領域を上下 100px 広げているため、
+      // ここでタッチの既定動作を止めると、矢印の近くから始めた縦スワイプでページをスクロール
+      // できなくなる (指が矢印に触れただけで画面が動かせない)。
+      // 代わりに、指が動いた場合はスワイプとみなしてページ送りを行わない。
+      let touchMoved = false;
+
+      const onTouchStart = () => {
         touchStartTime = Date.now();
-      }, { passive: false });
+        touchMoved = false;
+      };
 
-      leftArrow.addEventListener('touchend', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const touchEndTime = Date.now();
-        if (touchEndTime - touchStartTime < 300) { // 長押しを防ぐ
-          handlePageChange('prev');
-        }
-      }, { passive: false });
+      const onTouchMove = () => {
+        touchMoved = true;
+      };
 
-      rightArrow.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        touchStartTime = Date.now();
-      }, { passive: false });
+      const onTouchEnd = (direction) => (e) => {
+        if (touchMoved) return;                        // スワイプ (スクロール) だった
+        if (Date.now() - touchStartTime >= 300) return; // 長押しだった
 
-      rightArrow.addEventListener('touchend', (e) => {
-        e.preventDefault();
+        e.preventDefault();  // 直後に click が二重で発火するのを防ぐ
         e.stopPropagation();
-        const touchEndTime = Date.now();
-        if (touchEndTime - touchStartTime < 300) { // 長押しを防ぐ
-          handlePageChange('next');
-        }
-      }, { passive: false });
+        handlePageChange(direction);
+      };
+
+      [[leftArrow, 'prev'], [rightArrow, 'next']].forEach(([arrow, direction]) => {
+        arrow.addEventListener('touchstart', onTouchStart, { passive: true });
+        arrow.addEventListener('touchmove', onTouchMove, { passive: true });
+        arrow.addEventListener('touchend', onTouchEnd(direction), { passive: false });
+      });
 
       // クリックイベントの処理
       leftArrow.addEventListener('click', (e) => {

--- a/_includes/render-pdf-by-pdfjs.html
+++ b/_includes/render-pdf-by-pdfjs.html
@@ -91,6 +91,9 @@
     background: transparent;
     cursor: pointer;
     color: transparent;
+    /* ページ送りの矢印 (z-index: 1000) は当たり判定が広いため、リンクをその上に置く。
+       そうしないと、ページ端に近いリンクがクリックできない。 */
+    z-index: 1001;
   }
   .text-layer a:hover {
     background: rgba(255, 255, 0, 0.2);
@@ -217,8 +220,25 @@
 <script src="https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js"></script>
 
 <script>
+  // 一部の PDF はリンク注釈 (Link Annotation) を持っておらず、URL が「ただの文字」として
+  // 描かれている。そのままでは PDF.js がリンクを復元できないため、人が検証した URL を
+  // _data/application_links.yml から受け取り、PDF のテキストから位置を探して重ねる。
+  //
+  // URL の正しさは YAML 側で担保する。ここで URL を推測しない (誤ったリンクは、リンクが
+  // 無い状態より悪い。ユーザーが URL を目で読んで開く選択肢を奪い、黙って 404 へ飛ばす)。
+
+  // PDF に描かれた文字列と URL を照合するための正規化。
+  //   - 空白と改行を除去する: URL は行末で折り返されることがあり、途中に空白が入ることもある
+  //   - 結合文字 (U+0300〜U+036F) を除去する: アンダースコアが結合下線として埋め込まれた PDF がある
+  // _tests/verify_application_links.rb の normalize と同じルールにすること。
+  const IGNORED_IN_MATCH = /[\s\u0300-\u036F]/;
+
+  function normalizeForMatch(str) {
+    return Array.from(str).filter((ch) => !IGNORED_IN_MATCH.test(ch)).join('');
+  }
+
   // PDF.jsの初期化とPDF表示を行う関数
-  async function initPDF(projectId) {
+  async function initPDF(projectId, knownLinks) {
     // デバッグモードの設定（localhost または ngrok.io の場合に有効）
     const isDebug = window.location.hostname === 'localhost' || window.location.hostname.endsWith('.ngrok.io');
     const debugLog = (...args) => {
@@ -283,7 +303,7 @@
       const handlePageChange = async (direction) => {
         const now = Date.now();
         if (isProcessing || (now - lastTouchEndTime) < TOUCH_COOLDOWN) return;
-        
+
         isProcessing = true;
         lastTouchEndTime = now;
 
@@ -415,7 +435,7 @@
       const page = await pdfDocument.getPage(1);
       const commonObjs = page.commonObjs;
       debugLog('Common Objects:', commonObjs);
-      
+
       const fontObjs = page.objs;
       debugLog('Font Objects:', fontObjs);
 
@@ -425,13 +445,18 @@
       debugLog('Text Content Items:', textContent.items);
 
       numPages = pdfDocument.numPages;
-      
+
       // ページ情報を更新
       function updatePageInfo() {
         pageInfo.textContent = `ページ ${currentPage} / ${numPages}`;
         prevButton.disabled = currentPage <= 1;
         nextButton.disabled = currentPage >= numPages;
       }
+
+      // 描画の世代。ページを素早く切り替えると renderPage が同時に複数走り、
+      // 先に始まった描画が、後から始まった描画のテキストレイヤーを書き換えてしまう。
+      // 各 await の後で世代が変わっていたら、その描画は捨てる。
+      let renderGeneration = 0;
 
       // ページを表示する関数
       async function renderPage(pageNum) {
@@ -440,7 +465,12 @@
           return;
         }
 
+        const generation = ++renderGeneration;
+        const isStale = () => generation !== renderGeneration;
+
         const page = await pdfDocument.getPage(pageNum);
+        if (isStale()) return;
+
         const leftArrow = document.getElementById(`pdf-nav-arrow-left-${projectId}`);
         const rightArrow = document.getElementById(`pdf-nav-arrow-right-${projectId}`);
 
@@ -454,7 +484,7 @@
 
         // スケール値を計算（アスペクト比を維持）
         const scale = containerWidth / originalViewport.width;
-        const viewport = page.getViewport({ 
+        const viewport = page.getViewport({
           scale: scale,
           rotation: 0 // 回転を明示的に0度に設定
         });
@@ -462,16 +492,16 @@
         // canvasのピクセルサイズを設定
         const canvas = document.getElementById(`pdf-canvas-${projectId}`);
         const context = canvas.getContext('2d');
-        
+
         // デバイスピクセル比を考慮
         const dpr = window.devicePixelRatio || 1;
         canvas.width = viewport.width * dpr;
         canvas.height = viewport.height * dpr;
-        
+
         // CSSで幅100%、高さautoに
         canvas.style.width = `${viewport.width}px`;
         canvas.style.height = `${viewport.height}px`;
-        
+
         // コンテキストのスケーリング
         context.scale(dpr, dpr);
 
@@ -481,33 +511,48 @@
         textLayer.style.left = '0';
         textLayer.style.top = '0';
 
+        // PDF.js が生成する span は font-size に calc(var(--scale-factor) * Npx) を使う。
+        // この変数を設定しないと文字の大きさが決まらず、span の幅・高さが正しく求まらない。
+        textLayer.style.setProperty('--scale-factor', scale);
+
         // PDFを描画
         await page.render({
           canvasContext: context,
           viewport: viewport,
           intent: 'display'
         }).promise;
+        if (isStale()) return;
 
         // テキストレイヤー
         const textContent = await page.getTextContent();
+        if (isStale()) return;
         debugLog('Text content:', textContent);
-        
+
         // テキストレイヤーをクリア
         textLayer.innerHTML = '';
-        
+
+        // textDivs には、描画されたテキストの span が textContent.items と同じ順で入る。
+        // PDF にリンク注釈が無い場合、この span の位置からリンクの矩形を求める。
+        const textDivs = [];
+
         await pdfjsLib.renderTextLayer({
           textContent,
           container: textLayer,
           viewport,
-          textDivs: [],
+          textDivs,
           textContentSource: textContent,
           renderInteractiveForms: true,
           enhanceTextSelection: true
         }).promise;
+        if (isStale()) return;
 
         // リンクの処理
         const annotations = await page.getAnnotations();
+        if (isStale()) return;
         debugLog('Annotations:', annotations);
+
+        // 注釈から作ったリンクの矩形。あとでテキストから復元するリンクと重ならないようにする。
+        const annotationRects = [];
 
         for (const annotation of annotations) {
           if (annotation.subtype === 'Link') {
@@ -531,6 +576,8 @@
             link.style.width = `${width}px`;
             link.style.height = `${height}px`;
 
+            annotationRects.push({ left: x, top: y, right: x + width, bottom: y + height });
+
             // 外部リンクの場合
             if (annotation.url) {
               debugLog('External link:', annotation.url);
@@ -544,18 +591,18 @@
               debugLog('Internal link:', annotation.dest);
               link.href = '#';
               link.title = 'ページ内リンク';
-              
+
               // クリックイベントを設定
               link.addEventListener('click', async (e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 debugLog('Link clicked:', annotation.dest);
-                
+
                 try {
                   const dest = await pdfDocument.getDestination(annotation.dest);
                   const pageIndex = await pdfDocument.getPageIndex(dest[0]);
                   debugLog('Destination page:', pageIndex + 1);
-                  
+
                   if (pageIndex !== -1) {
                     currentPage = pageIndex + 1;
                     await renderPage(currentPage);
@@ -572,7 +619,100 @@
           }
         }
 
+        // リンク注釈を持たない PDF のために、人が検証した URL をテキストの上に重ねる
+        renderKnownLinks(pageNum, textContent.items, textDivs, annotationRects);
+
         updatePageInfo();
+      }
+
+      // _data/application_links.yml に登録された URL を、PDF のテキストの上に重ねる。
+      function renderKnownLinks(pageNum, items, textDivs, annotationRects) {
+        const links = knownLinks.filter((link) => link.page === pageNum);
+        if (links.length === 0) return;
+
+        // span と item が 1 対 1 で対応しなければ、位置を特定できないので何もしない。
+        // リンクが増えないだけで、表示・テキスト選択・ページ送りには影響しない。
+        if (textDivs.length !== items.length) {
+          debugLog('span と item の数が一致しないため、リンクの復元を見送ります:', textDivs.length, items.length);
+          return;
+        }
+
+        // 正規化した全文と、その各文字がどの item から来たかの対応表を作る
+        let text = '';
+        const itemOfChar = [];
+
+        items.forEach((item, index) => {
+          for (const ch of item.str) {
+            if (IGNORED_IN_MATCH.test(ch)) continue;
+            text += ch;
+            itemOfChar.push(index);
+          }
+        });
+
+        links.forEach((link) => {
+          const key = normalizeForMatch(link.match || link.url);
+          const at = text.indexOf(key);
+
+          if (at === -1) {
+            debugLog('PDF のテキストから見つかりませんでした:', link.url);
+            return;
+          }
+
+          rectsOf(itemOfChar[at], itemOfChar[at + key.length - 1], textDivs).forEach((rect) => {
+            // 注釈から作ったリンクと重なる場合は、そちらを優先して二重に貼らない
+            if (annotationRects.some((annotation) => overlaps(annotation, rect))) return;
+
+            const a = document.createElement('a');
+            a.className = 'pdf-text-link';
+            a.href = link.url;
+            a.target = '_blank';
+            a.title = link.url;
+            a.style.left = `${rect.left}px`;
+            a.style.top = `${rect.top}px`;
+            a.style.width = `${rect.right - rect.left}px`;
+            a.style.height = `${rect.bottom - rect.top}px`;
+            textLayer.appendChild(a);
+
+            debugLog('テキストからリンクを復元しました:', link.url);
+          });
+        });
+      }
+
+      // item の範囲に対応する span の矩形を、行ごとにまとめて返す。
+      // URL は行末で折り返されることがあり、1 つのリンクが複数行にまたがる。
+      function rectsOf(firstItem, lastItem, textDivs) {
+        const rects = [];
+
+        for (let i = firstItem; i <= lastItem; i++) {
+          const div = textDivs[i];
+          if (!div) continue;
+
+          // 大きさを持たない span (空文字など) は行の位置を持たないので飛ばす。
+          // 拾ってしまうと、左上 (0, 0) に大きさ 0 のリンクができる。
+          if (div.offsetWidth === 0 || div.offsetHeight === 0) continue;
+
+          const rect = {
+            left: div.offsetLeft,
+            top: div.offsetTop,
+            right: div.offsetLeft + div.offsetWidth,
+            bottom: div.offsetTop + div.offsetHeight
+          };
+          const sameRow = rects.find((r) => Math.abs(r.top - rect.top) < (rect.bottom - rect.top) / 2);
+
+          if (sameRow) {
+            sameRow.left = Math.min(sameRow.left, rect.left);
+            sameRow.right = Math.max(sameRow.right, rect.right);
+            sameRow.bottom = Math.max(sameRow.bottom, rect.bottom);
+          } else {
+            rects.push(rect);
+          }
+        }
+
+        return rects;
+      }
+
+      function overlaps(a, b) {
+        return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
       }
 
       // 最初のページを表示
@@ -625,7 +765,7 @@
     } catch (error) {
       clearTimeout(loadingTimeout);
       console.error('PDFの読み込みに失敗しました:', error);
-      
+
       // エラーメッセージを詳細に表示
       let errorMessage = 'PDFの読み込みに失敗しました。';
       if (error.name === 'MissingPDFException') {
@@ -638,7 +778,7 @@
 
       loadingText.textContent = errorMessage;
       loadingText.style.color = '#dc3545';
-      
+
       // リトライボタンを表示
       const retryButton = document.createElement('button');
       retryButton.textContent = '再読み込み';
@@ -653,6 +793,11 @@
 
   // ページ読み込み完了時にPDFを表示
   document.addEventListener('DOMContentLoaded', () => {
-    initPDF('{{ include.project_id }}');
+    {% assign application = site.data.application_links | where: "project_id", include.project_id | first %}
+    {% if application %}
+    initPDF('{{ include.project_id }}', {{ application.links | jsonify }});
+    {% else %}
+    initPDF('{{ include.project_id }}', []);
+    {% endif %}
   });
 </script>

--- a/_tasks/extract_application_links.rb
+++ b/_tasks/extract_application_links.rb
@@ -1,0 +1,52 @@
+# 提案書 PDF から URL 候補を抽出し、_data/application_links.yml の下書きを出力する。
+#
+# 出力はあくまで「下書き」であり、そのまま使ってはいけない。
+# PDF に描かれた文字列は、行末で折り返されたり、途中に空白が入っていたりして、
+# そのままでは正しい URL にならないことがある。誤ったリンクを貼ると、リンクが無い状態より
+# 悪化する (ユーザーが URL を目で読んで開くという選択肢を奪い、黙って 404 へ飛ばす)。
+#
+# 出力を PDF と照らし合わせて確認し、_data/application_links.yml に手で反映すること。
+# 反映後は次のコマンドで、PDF のテキストと照合できるか検証する。
+#
+#   bundle exec rake verify_application_links
+
+require 'open3'
+
+PDF_DIR = 'applications'
+
+# 行末で折り返された URL を、次の行と連結する。
+# 次の行が URL の続きに見える場合 (URL に使える文字だけで構成され、新しい URL で始まらない) に限る。
+def urls_in_page(pdf, page)
+  text, = Open3.capture2('pdftotext', '-layout', '-f', page.to_s, '-l', page.to_s, pdf, '-')
+  lines = text.lines.map(&:chomp)
+
+  lines.each_with_index.flat_map do |line, i|
+    line.scan(%r{https?://\S+}).map do |url|
+      continues_to_next_line = line.end_with?(url)
+      next_line = lines[i + 1].to_s
+
+      if continues_to_next_line && next_line.match?(%r{\A[\w%\-?=&/.#@]+\z}) && !next_line.match?(%r{\Ahttps?://})
+        url += next_line
+      end
+
+      url.sub(/[.,)）」』]+\z/, '')
+    end
+  end
+end
+
+Dir.glob(File.join(PDF_DIR, '*.pdf')).sort.each do |pdf|
+  project_id = File.basename(pdf, '.pdf')
+  pages = `pdfinfo "#{pdf}"`[/Pages:\s+(\d+)/, 1].to_i
+  links = (1..pages).flat_map { |page| urls_in_page(pdf, page).map { |url| [page, url] } }.uniq
+
+  next if links.empty?
+
+  puts "- project_id: #{project_id}"
+  puts '  links:'
+  links.each do |page, url|
+    puts "    - page: #{page}"
+    puts "      url: #{url}"
+  end
+end
+
+warn "\n上記は下書きです。必ず PDF を目視して確認してから _data/application_links.yml に反映してください。"

--- a/_tests/verify_application_links.rb
+++ b/_tests/verify_application_links.rb
@@ -1,0 +1,75 @@
+# _data/application_links.yml に書かれたリンクが、実際に PDF の中から見つかることを検証する。
+#
+# PDF ビューア (_includes/render-pdf-by-pdfjs.html) は、YAML の URL を PDF のテキストから
+# 探して、その位置にリンクを重ねる。つまり「YAML の URL が PDF のテキストと照合できること」が
+# リンクを貼れる前提条件になる。ここが崩れると、リンクは黙って貼られなくなる。
+#
+# 照合は JavaScript 側と同じ正規化ルールで行う (normalize を参照)。
+#
+#   bundle exec rake verify_application_links
+
+require 'open3'
+require 'yaml'
+
+DATA_FILE = '_data/application_links.yml'
+PDF_DIR   = 'applications'
+
+# JavaScript 側 (normalizeForMatch) と同じ正規化ルール。
+#
+#   - 空白と改行を除去する: PDF は行末で URL を折り返すことがあり、
+#     さらに URL の途中に空白が入っていることもある (fudey)
+#   - 結合文字 (U+0300〜U+036F) を除去する: アンダースコアが結合下線として
+#     埋め込まれていることがある (abecobe)
+def normalize(str)
+  str.gsub(/[[:space:]]/, '').gsub(/[\u{0300}-\u{036F}]/, '')
+end
+
+def page_text(pdf, page)
+  text, status = Open3.capture2('pdftotext', '-layout', '-f', page.to_s, '-l', page.to_s, pdf, '-')
+  raise "pdftotext に失敗しました: #{pdf} p#{page}" unless status.success?
+
+  normalize(text)
+end
+
+entries = YAML.load_file(DATA_FILE)
+failures = []
+checked = 0
+
+entries.each do |entry|
+  id  = entry['project_id']
+  pdf = File.join(PDF_DIR, "#{id}.pdf")
+
+  unless File.exist?(pdf)
+    failures << "#{id}: PDF が見つかりません (#{pdf})"
+    next
+  end
+
+  entry['links'].each do |link|
+    page = link['page']
+    url  = link['url']
+    key  = normalize(link['match'] || url)
+    checked += 1
+
+    unless url.start_with?('http://', 'https://')
+      failures << "#{id} p#{page}: URL が http(s) で始まっていません: #{url}"
+      next
+    end
+
+    unless page_text(pdf, page).include?(key)
+      failures << "#{id} p#{page}: PDF のテキストから見つかりません\n" \
+                  "    url:   #{url}\n" \
+                  "    照合キー: #{link['match'] || url}"
+    end
+  end
+end
+
+puts "\n#{checked} 件のリンクを #{entries.size} 本の PDF で検証しました。"
+
+if failures.empty?
+  puts "すべて PDF のテキストと照合できました。"
+else
+  puts "\n照合できなかったリンクが #{failures.size} 件あります:\n\n"
+  failures.each { |f| puts "  - #{f}" }
+  puts "\nPDF を目視して、_data/application_links.yml の url または match を修正してください。"
+  abort
+end


### PR DESCRIPTION
Fix #226

<img width="577" height="340" alt="image" src="https://github.com/user-attachments/assets/552848d9-bf1d-494a-bdb7-01debbd2b438" />

## 原因

提案書 PDF の一部は **リンク注釈 (Link Annotation) を持っていません**。iLovePDF による圧縮や、macOS の「印刷」経由での書き出しで注釈が失われるためです。注釈が無いと PDF.js はリンクを復元できず、URL は「ただの文字」として描かれます。

`niwangojs` と `det_exploit` がこれに該当しました（PDF.js が注釈を1つも認識しません）。

## なぜ自動検出にしなかったか

「テキストから URL を正規表現で拾ってリンクにする」案は採りませんでした。**PDF に描かれた文字列は、そのままでは正しい URL にならない**からです。

| PDF | 描かれている文字列 | 正しい URL |
|---|---|---|
| `fudey` | `.../article/20120928- a140/` （途中に空白） | `.../article/20120928-a140/` |
| `abecobe` | `...jpl̲gb...` （`_` が結合文字 U+0332） | `...jpl_gb...` |
| `jellyfish_alert` | 行末で折り返され、2行に分かれる | 連結が必要 |
| `uminavi` | 3行に折り返される | 連結が必要 |

自動検出の失敗モードは「リンクが付かない」ではなく **「間違ったリンクが付く」** です。これはリンクが無い現状より悪化します（ユーザーが URL を目で読んで開く選択肢を奪い、黙って 404 へ飛ばす）。

## 方針

**URL の正しさは人が担保し、JavaScript は位置決めだけを担当する**分業にしました。

- `_data/application_links.yml` — 人が PDF を目視して確定した URL（47件）
- `_includes/render-pdf-by-pdfjs.html` — YAML の URL を PDF のテキストから探し、その位置にリンクを重ねる
  - 空白・改行・結合文字を無視して照合するので、折り返しや空白混入があっても見つかる
  - **PDF が注釈を持つ場合はそちらを優先**し、同じ場所に二重にリンクを貼らない
- `_tests/verify_application_links.rb` — YAML の URL が PDF から見つかるかを検証（CI でも実行）
- `_tasks/extract_application_links.rb` — URL 候補を抽出して下書きを作る（要目視確認）

<!--
## あわせて直した問題

リンクを描くにあたって、既存実装の次の問題も見つかったので直しました。

### スクロールを奪っていた問題

PDF ビューアの上でマウスホイールが吸われ、ページを読み進められませんでした。

原因は `.pdf-container` の `overflow-y: auto` です。canvas の高さは PDF の viewport から計算されるため端数を持ち（例 1128.6px）、コンテナの `scrollHeight` が `clientHeight` より **1px** 大きくなります。この 1px が「スクロールできる領域」とみなされ、ホイールがコンテナに消費されてページに伝わりませんでした。

```
client=1128  scroll=1129  → はみ出し 1px   （実測）
```

1ページずつ描画してボタンで送るビューアなので、内部スクロールはそもそも不要です。`overflow: clip` にして、はみ出しは切りつつスクロール領域を作らないようにしました（`hidden` はスクロールコンテナを作ってしまうため不適）。

モバイルでも同じ問題がありました。ページ送りの矢印はタップ領域を上下 100px 広げているのに `touchstart` で `preventDefault()` していたため、**矢印の近くから始めた縦スワイプで画面をスクロールできません**でした。`touchstart` では既定動作を止めず、指が動いた場合はスワイプとみなしてページ送りを行わないようにしました。

### その他

- **描画の競合** — ページを素早く切り替えると `renderPage` が同時に走り、リンクが前のページのまま残ることがあった（描画に世代を持たせ、古い描画を捨てる）
- **ページ送りの矢印がリンクを覆う** — 矢印の当たり判定が上下 ±100px に広がっており、ページ端のリンクがクリックできなかった（リンクを矢印より上に置く）
- **`--scale-factor` の未設定** — PDF.js 3.x はこの CSS 変数を要求するが未設定で、文字の大きさが定まらず、テキストの位置を正しく求められなかった
-->

## 検証

ヘッドレスブラウザで実際に描画し、リンクの当たり判定を可視化して確認しました。

- ✅ `niwangojs` 2ページ目（Issue 記載のリンク）にリンクが生成される
- ✅ `det_exploit` 1ページ目の URL の上に、当たり判定がぴったり重なる
- ✅ `jellyfish_alert` / `abecobe`（注釈あり）では二重リンクにならない（注釈由来のみ）
- ✅ スクロールを奪わない（`scrollTop` に 500 を代入しても 0 のまま＝スクロールコンテナではない）
- ✅ テキスト選択・ページ送り・縮尺・向きに退行なし
- ✅ `bundle exec rake test`（html-proofer）通過
- ✅ `bundle exec rake verify_application_links` で 47 件すべて照合
