### PR TITLE
fix/prevent forced dark mode

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
 <html lang="{{ lang }}" dir="ltr">
 <head>
   <meta charset="utf-8">
+  <meta name="color-scheme" content="only light">
 
   {% if page.title %}
   <title>{{ page.title | strip_html }} - {{ translations.title[lang] }}</title>


### PR DESCRIPTION
https://x.com/kn1cht/status/2096206473340862791
強制ダークモード時を適用した際に文字が見にくくなる問題があるため、`_includes/head.html`に `<meta name="color-scheme" content="only light">` を追加し、このサイトがライトモードのみに対応していることを明示しました。

参考 : [color-scheme - CSS | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme#:~:text=Can%20be%20used%20to%20turn%20off%20color%20overrides%20caused%20by%20Chrome%27s%20Auto%20Dark%20Theme%2C%20by%20applying%20color%2Dscheme%3A%20only%20light%3B%20on%20a%20specific%20element%20or%20%3Aroot%2E)